### PR TITLE
BACKLOG-23366: Disable --immutable yarn option during release

### DIFF
--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -166,7 +166,22 @@
                     </instructions>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <!-- equivalent of 'yarn clean-server' -->
+                            <directory>${project.basedir}/src/main/resources/META-INF/js/</directory>
+                        </fileset>
+                        <fileset>
+                            <!-- equivalent of 'yarn clean-client' -->
+                            <directory>${project.basedir}/src/main/resources/javascript/</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
@@ -177,34 +192,6 @@
                     </environmentVariables>
                 </configuration>
                 <executions>
-                    <execution>
-                        <id>npm install node and yarn pre-clean</id>
-                        <phase>pre-clean</phase>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                        <configuration>
-                            <nodeVersion>${frontend-maven-plugin.nodeVersion}</nodeVersion>
-                            <yarnVersion>${frontend-maven-plugin.yarnVersion}</yarnVersion>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>yarn install pre-clean</id>
-                        <phase>pre-clean</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>clean</arguments>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>npm install node and yarn</id>
                         <phase>initialize</phase>
@@ -271,4 +258,23 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>release-additional-goals</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- by default on CI environment, yarn has the "immutable" option set -->
+                        <!-- however, during the release process (i.e. with the "release-additional-goals" profile enabled,
+                        it must be explicitly disabled to recompute the checksums in the yarn.lock files after the version change -->
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <configuration>
+                            <arguments>--no-immutable</arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/javascript-modules-library/pom.xml
+++ b/javascript-modules-library/pom.xml
@@ -48,6 +48,18 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <!-- equivalent of 'yarn clean' -->
+                            <directory>${project.basedir}/dist/</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <!-- use an Ant task to create the target/ directory, as it's not created by Maven for "pom" packaging -->
@@ -68,36 +80,6 @@
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <executions>
-                    <!-- Executions bound on the "pre-clean" phase: -->
-                    <execution>
-                        <id>npm install node and yarn pre-clean</id>
-                        <phase>pre-clean</phase>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                        <configuration>
-                            <nodeVersion>${node.version}</nodeVersion>
-                            <yarnVersion>${yarn.version}</yarnVersion>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>yarn install pre-clean</id>
-                        <phase>pre-clean</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                    </execution>
-                    <!-- Execution bound on the "clean" phase: -->
-                    <execution>
-                        <id>yarn clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>clean</arguments>
-                        </configuration>
-                    </execution>
                     <!-- Executions bound on the "initialize" phase (executed in order of declaration): -->
                     <execution>
                         <id>install node, yarn and npm</id>
@@ -140,10 +122,10 @@
                             <arguments>build</arguments>
                         </configuration>
                     </execution>
-                    <!-- Execution bound on the "deploy" phase: -->
+                    <!-- Execution bound on any phase that can be executed using its id: -->
                     <execution>
                         <id>publish-package</id>
-                        <phase>deploy</phase>
+                        <phase>none</phase>
                         <goals>
                             <goal>npm</goal>
                         </goals>
@@ -191,6 +173,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <goals>deploy frontend-maven-plugin@publish-package</goals>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,22 @@
         </repository>
     </repositories>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <!-- when releasing, the checksum of the javascript-modules-library package in the yarn.lock files changes -->
+                    <!-- 'clean verify/install' is used to recompute the checksum of the yarn.lock files as part of the regular Maven build -->
                     <!-- scm:checkin allows to commit those files -->
                     <preparationGoals>-P release-additional-goals clean verify scm:checkin</preparationGoals>
                     <completionGoals>-P release-additional-goals clean install scm:checkin</completionGoals>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23366

## Description

Address several issues of the release process:
- **immutable yarn option**: by default on CI, yarn has the `--immutable` flag enabled which fails a yarn command if the `yarn.lock` was to be modified. This behaviour has to be disabled during the release process (and only during that workflow) to let the CI updates the `yarn.lock` file with the new checksum based on the new version being released
- **clean handled by Maven**: before, the `mvn clean` was delegating the `clean` action to `yarn clean`, which requires to have valid links to the packages declared as dependencies. However, with the multi-module structure, a `mvn clean` from the root directory will wipe out the `javascript-modules-library/dist/` folder (as the _javascript-modules-library_ is processed first). But that folder is referenced in [`javascript-modules-engine/yarn.lock`](https://github.com/Jahia/javascript-modules/blob/main/javascript-modules-engine/yarn.lock#L1352), causing the command to fail (NB: it *does* work when running a `mvn clean install` as Maven will first execute the `clean` and `install` command on the _javascript-modules-library_ before running the same on the _javascript-modules-engine_). The fix is to use Maven directly to perform the clean action.
- **limit package publication**: the package should be published to npmjs.com only during the release process, and not when doing a simple `mvn deploy` (which is done when building the _main_ branch, see [this build](https://github.com/Jahia/javascript-modules/actions/runs/11954442702/job/33326428136) for an example - that failed as the credentials were not provided). The solution is to specify the exact plugin execution to run during the release process

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
