### PR TITLE
BACKLOG-23366: Fix release of NPM package

### DIFF
--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -247,12 +247,12 @@
     </build>
     <profiles>
         <profile>
-            <id>release-additional-goals</id>
+            <id>release-prepare</id>
             <build>
                 <plugins>
                     <plugin>
                         <!-- by default on CI environment, yarn has the "immutable" option set -->
-                        <!-- however, during the release process (i.e. with the "release-additional-goals" profile enabled,
+                        <!-- however, during the release preparation process (i.e. with the "release-prepare" profile enabled),
                         it must be explicitly disabled to recompute the checksums in the yarn.lock files after the version change -->
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>

--- a/javascript-modules-library/pom.xml
+++ b/javascript-modules-library/pom.xml
@@ -122,18 +122,6 @@
                             <arguments>build</arguments>
                         </configuration>
                     </execution>
-                    <!-- Execution bound on any phase that can be executed using its id: -->
-                    <execution>
-                        <id>publish-package</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <!-- publish the tgz in the target/ folder as its package.json is properly filtered (with the right version) -->
-                            <arguments>publish ${project.build.directory}/${project.build.finalName}.tgz --access public</arguments>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -174,13 +162,34 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <goals>deploy frontend-maven-plugin@publish-package</goals>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>release-perform</id>
+            <!-- publish the tgz during the release:perform task (i.e. when the profile "release-perform" is enabled) -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Execution bound on the "deploy" phase: -->
+                            <execution>
+                                <id>publish-package</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- publish the tgz in the target/ folder as its package.json is properly filtered (with the right version) -->
+                                    <arguments>publish ${project.build.directory}/${project.build.finalName}.tgz --access public</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,15 +73,17 @@
                     <!-- when releasing, the checksum of the javascript-modules-library package in the yarn.lock files changes -->
                     <!-- 'clean verify/install' is used to recompute the checksum of the yarn.lock files as part of the regular Maven build -->
                     <!-- scm:checkin allows to commit those files -->
-                    <preparationGoals>-P release-additional-goals clean verify scm:checkin</preparationGoals>
-                    <completionGoals>-P release-additional-goals clean install scm:checkin</completionGoals>
+                    <preparationGoals>-P release-prepare clean verify scm:checkin</preparationGoals>
+                    <completionGoals>-P release-prepare clean install scm:checkin</completionGoals>
+                    <releaseProfiles>release-perform</releaseProfiles>
+                    <useReleaseProfile>true</useReleaseProfile>
                 </configuration>
             </plugin>
         </plugins>
     </build>
     <profiles>
         <profile>
-            <id>release-additional-goals</id>
+            <id>release-prepare</id>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23366

## Description

Use a specific Maven profile "release-perform" during the release process via the _Maven Release Plugin_ (i.e. with `mvn release:perform`) to enable the NPM publication of the package.
Also, for consistency, the previous Maven profile "release-additional-goals" got renamed to "release-prepare" (as it is used by `mvn release:prepare`).

### Bug description

The `goals` of the _Maven Release Plugin_  were overwritten in the Maven module `javascript-modules-library/pom.xml` and that was correctly showing up when doing a `mvn help:effective-pom`.
However, the _Maven Release Plugin_  is a bit different from the regular Maven plugins when dealing with multi-module projects as it it is triggered only for the parent project, and not for the each module (as it is the case for goals like `clean`, `compile`, `package`, etc.). Because of that, the configuration defined in the child module was ignored.
