### PR TITLE
BACKLOG-23366: Pass NPM token to release action

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -49,8 +49,7 @@ jobs:
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
           mvn_settings_filepath: '.github/maven.settings.xml'
           slack-webhook-qa: ${{ secrets.SLACK_WEBHOOK_URL_RC_FOR_QA }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
+          npmjs_publish_token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
 
 
       - uses: jahia/jahia-modules-action/update-signature@v2


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23366

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Pass the new `npmjs_publish_token` parameter for the release action in order to have the `.npmrc` properly configured when the `npm publish` command is run from the Maven build.

### ⚠️ Dependencies ⚠️ 

- [ ] https://github.com/Jahia/jahia-modules-action/pull/160 must be merged and integrated to `v2`