### PR TITLE
TECH-2021: Automatically bump @jahia/cypress version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Ensure the latest @jahia/cypress package is used
+  - package-ecosystem: "npm" # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#yarn
+    directory: "javascript-modules-engine/tests/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@jahia/cypress"
+        dependency-type: "development"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/TECH-2021

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Check everyday if a new version of the `@jahia/cypress` package is available and create a new PR in this case.
This should help us to stay up-to-date with this framework package.

If successful and adopted by the team, we could deploy a similar setup for the rest of the repositories using `@jahia/cypress`.
