### PR TITLE
TECH-1880: Update HTML id used to select an element in a test

### DIFF
--- a/javascript-modules-engine/tests/cypress/e2e/module/moduleSettingsTest.cy.ts
+++ b/javascript-modules-engine/tests/cypress/e2e/module/moduleSettingsTest.cy.ts
@@ -33,7 +33,7 @@ describe('Check that NPM module settings (UI extensions, rules, configs) are cor
         const jcontent = new JContentPageBuilder(JContent.visit('npmTestSite', 'en', 'pages/home/testModuleSettings'));
         jcontent.getModule('/sites/npmTestSite/home/testModuleSettings/pagecontent').get().scrollIntoView();
         jcontent.getModule('/sites/npmTestSite/home/testModuleSettings/pagecontent/testContentEditorExtension').doubleClick();
-        getComponentBySelector(Collapsible, '[data-sel-content-editor-fields-group="Classification and Metadata"]').shouldBeExpanded();
+        getComponentBySelector(Collapsible, '[data-sel-content-editor-fields-group="metadata"]').shouldBeExpanded();
         cy.logout();
     });
 

--- a/javascript-modules-engine/tests/package.json
+++ b/javascript-modules-engine/tests/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^2.2.1",
-    "@jahia/cypress": "^3.34.0",
+    "@jahia/cypress": "^3.35.0",
     "@jahia/jahia-reporter": "^1.0.30",
     "@jahia/jcontent-cypress": "^3.0.0-tests.8",
     "@types/node": "^18.11.18",

--- a/javascript-modules-engine/tests/yarn.lock
+++ b/javascript-modules-engine/tests/yarn.lock
@@ -165,9 +165,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jahia/cypress@npm:^3.34.0":
-  version: 3.34.0
-  resolution: "@jahia/cypress@npm:3.34.0"
+"@jahia/cypress@npm:^3.35.0":
+  version: 3.35.0
+  resolution: "@jahia/cypress@npm:3.35.0"
   dependencies:
     "@apollo/client": "npm:^3.4.9"
     cypress-real-events: "npm:^1.11.0"
@@ -178,7 +178,7 @@ __metadata:
     ci.startup: ci.startup.sh
     env.debug: env.debug.sh
     env.run: env.run.sh
-  checksum: 10c0/b3fbb673d4409b9d99bf626baa5cd4b730d50d231177a7761d4cbd48fbadc444ec1d06f18dbe3c2d19d2a063cf312eb495c2c7ffd387944fb5991b0abc5aa4cd
+  checksum: 10c0/91da095565d7b8008e6e4a8e53d6c9714de8c5310f84d7f3baa1659eb5226a6a5ec49f1bdd31242f140d8a035cc7879e40fe083a8db4c20d1c314ff2956e5811
   languageName: node
   linkType: hard
 
@@ -224,7 +224,7 @@ __metadata:
   resolution: "@jahia/javascript-modules-engine-cypress@workspace:."
   dependencies:
     "@4tw/cypress-drag-drop": "npm:^2.2.1"
-    "@jahia/cypress": "npm:^3.34.0"
+    "@jahia/cypress": "npm:^3.35.0"
     "@jahia/jahia-reporter": "npm:^1.0.30"
     "@jahia/jcontent-cypress": "npm:^3.0.0-tests.8"
     "@types/node": "npm:^18.11.18"


### PR DESCRIPTION
https://jira.jahia.org/browse/TECH-1880
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description


An HTML identifier has been renamed in https://github.com/Jahia/jcontent/pull/1367, more specifically [here](https://github.com/Jahia/jcontent/pull/1367/files#diff-46e6b939eae9f9b09395725ce1c3ca5fa751ed12da2d66c8be8cbfb1115e3d27R45) to use the name of the section instead of the display name, which broke a Cypress test.
Also, bump to version 3.35.0 for the @jahia/cypress dependency to include [this change](https://github.com/Jahia/jahia-cypress/pull/99).
