### PR TITLE
TECH-1880: Update HTML id used to select an element in a test

### DIFF
--- a/javascript-modules-engine/tests/cypress/e2e/module/moduleSettingsTest.cy.ts
+++ b/javascript-modules-engine/tests/cypress/e2e/module/moduleSettingsTest.cy.ts
@@ -33,7 +33,7 @@ describe('Check that NPM module settings (UI extensions, rules, configs) are cor
         const jcontent = new JContentPageBuilder(JContent.visit('npmTestSite', 'en', 'pages/home/testModuleSettings'));
         jcontent.getModule('/sites/npmTestSite/home/testModuleSettings/pagecontent').get().scrollIntoView();
         jcontent.getModule('/sites/npmTestSite/home/testModuleSettings/pagecontent/testContentEditorExtension').doubleClick();
-        getComponentBySelector(Collapsible, '[data-sel-content-editor-fields-group="Classification and Metadata"]').shouldBeExpanded();
+        getComponentBySelector(Collapsible, '[data-sel-content-editor-fields-group="metadata"]').shouldBeExpanded();
         cy.logout();
     });
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->
https://jira.jahia.org/browse/TECH-1880
## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
An HTML identifier has been renamed in https://github.com/Jahia/jcontent/pull/1367, more specifically [here](https://github.com/Jahia/jcontent/pull/1367/files#diff-46e6b939eae9f9b09395725ce1c3ca5fa751ed12da2d66c8be8cbfb1115e3d27R45) to use the name of the section instead of the display name, which broke a Cypress test.
