### PR TITLE
SEC-122: Mark java-ts-bind as a provided dependency

### DIFF
--- a/javascript-modules-engine-java/pom.xml
+++ b/javascript-modules-engine-java/pom.xml
@@ -73,7 +73,7 @@
             <artifactId>java-ts-bind</artifactId>
             <version>1.0.0-jahia-2</version>
             <classifier>all</classifier>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <!-- dependencies not present / different required to generate the *d.ts files: -->
         <dependency>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->
https://jira.jahia.org/browse/SEC-122
## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Change the scope of the `java-ts-bind` dependency to `provided` to exclude the library from the Sonar analysis (done by the `-DskipProvidedScope=true` parameter in https://github.com/Jahia/jahia-modules-action/blob/main/sonar-analysis/action.yml#L116).
This should prevent SonarQube to list the security vulnerabilities related to the `java-ts-bind` dependency (see https://sonarqube.jahia.com/project/issues?resolved=false&types=VULNERABILITY&inNewCodePeriod=false&id=org.jahia.modules%3Ajavascript-modules).
