### PR TITLE
TECH-2048: Bump nexus-staging-maven-plugin to 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
 
     <properties>
         <graalvm.sdk.version>23.0.2</graalvm.sdk.version>
+        <!-- override the version of org.sonatype.plugins:nexus-staging-maven-plugin to ensure compatibility with JDK 17 -->
+        <nexus.maven.plugin.version>1.7.0</nexus.maven.plugin.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->
https://jira.jahia.org/browse/TECH-2048

## Description

Bump the version of the plugin _org.sonatype.plugins:nexus-staging-maven-plugin_ to 1.7.0 (from 1.5.1), as the previous version is not compatible with JDK 17.

**NB:** https://github.com/Jahia/jahia-private/pull/2371 is not enough as _javascript-modules_ has its parent _org.jahia.modules:jahia-modules_ in version 8.2.0.0 (thus, without the bump of version).

