### PR TITLE
build: add scripts to the mono repository

### DIFF
--- a/javascript-modules-engine/tests/jahia-module/yarn.lock
+++ b/javascript-modules-engine/tests/jahia-module/yarn.lock
@@ -1703,7 +1703,7 @@ __metadata:
 
 "@jahia/javascript-modules-library@file:../../../javascript-modules-library/dist::locator=%40jahia%2Fnpm-module-example%40workspace%3A.":
   version: 0.4.0-SNAPSHOT
-  resolution: "@jahia/javascript-modules-library@file:../../../javascript-modules-library/dist#../../../javascript-modules-library/dist::hash=3d895a&locator=%40jahia%2Fnpm-module-example%40workspace%3A."
+  resolution: "@jahia/javascript-modules-library@file:../../../javascript-modules-library/dist#../../../javascript-modules-library/dist::hash=f5e20b&locator=%40jahia%2Fnpm-module-example%40workspace%3A."
   dependencies:
     dotenv: "npm:^16.4.7"
     graphql: "npm:^16.0.1"
@@ -1728,7 +1728,7 @@ __metadata:
       optional: true
   bin:
     jahia-deploy: bin/jahia-deploy.mjs
-  checksum: 10/0f5553384f866e1374095fb25df8089cf2286730fb793fcfaa3b2fd9d5ad854ed54319f34f334c3f28f3cbb5c53fb69e3a66eee34905727cdc5d9c1b369d9529
+  checksum: 10/a4ec52b065a544a4b0d5753b8304bfbc51ed792e2dfcbb480d9a85c344dbbb6ccb0bf5bd497fde0d45b9f8ce36fd9a5223cc3dc648b1f4b063056088cee1b0f4
   languageName: node
   linkType: hard
 

--- a/javascript-modules-engine/tests/jahia-module/yarn.lock
+++ b/javascript-modules-engine/tests/jahia-module/yarn.lock
@@ -1703,8 +1703,9 @@ __metadata:
 
 "@jahia/javascript-modules-library@file:../../../javascript-modules-library/dist::locator=%40jahia%2Fnpm-module-example%40workspace%3A.":
   version: 0.4.0-SNAPSHOT
-  resolution: "@jahia/javascript-modules-library@file:../../../javascript-modules-library/dist#../../../javascript-modules-library/dist::hash=9e300c&locator=%40jahia%2Fnpm-module-example%40workspace%3A."
+  resolution: "@jahia/javascript-modules-library@file:../../../javascript-modules-library/dist#../../../javascript-modules-library/dist::hash=3d895a&locator=%40jahia%2Fnpm-module-example%40workspace%3A."
   dependencies:
+    dotenv: "npm:^16.4.7"
     graphql: "npm:^16.0.1"
     graphql-tag: "npm:^2.12.6"
     prop-types: "npm:^15.8.1"
@@ -1725,7 +1726,9 @@ __metadata:
       optional: true
     styled-jsx:
       optional: true
-  checksum: 10/9cc7e6803a50ed8418b64983574889bb5d760f4acb39aab6c9f4c61b26c7d9563e97acaea31d34d144c54b58325cc01e3cb344ddd9fae9c24f6881aa03892454
+  bin:
+    jahia-deploy: bin/jahia-deploy.mjs
+  checksum: 10/0f5553384f866e1374095fb25df8089cf2286730fb793fcfaa3b2fd9d5ad854ed54319f34f334c3f28f3cbb5c53fb69e3a66eee34905727cdc5d9c1b369d9529
   languageName: node
   linkType: hard
 
@@ -3512,6 +3515,13 @@ __metadata:
   version: 16.3.1
   resolution: "dotenv@npm:16.3.1"
   checksum: 10/dbb778237ef8750e9e3cd1473d3c8eaa9cc3600e33a75c0e36415d0fa0848197f56c3800f77924c70e7828f0b03896818cd52f785b07b9ad4d88dba73fbba83f
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.4.7":
+  version: 16.4.7
+  resolution: "dotenv@npm:16.4.7"
+  checksum: 10/f13bfe97db88f0df4ec505eeffb8925ec51f2d56a3d0b6d916964d8b4af494e6fb1633ba5d09089b552e77ab2a25de58d70259b2c5ed45ec148221835fc99a0c
   languageName: node
   linkType: hard
 

--- a/javascript-modules-engine/yarn.lock
+++ b/javascript-modules-engine/yarn.lock
@@ -1277,8 +1277,9 @@ __metadata:
 
 "@jahia/javascript-modules-library@file:../javascript-modules-library/dist::locator=javascript-modules-engine%40workspace%3A.":
   version: 0.4.0-SNAPSHOT
-  resolution: "@jahia/javascript-modules-library@file:../javascript-modules-library/dist#../javascript-modules-library/dist::hash=2a2152&locator=javascript-modules-engine%40workspace%3A."
+  resolution: "@jahia/javascript-modules-library@file:../javascript-modules-library/dist#../javascript-modules-library/dist::hash=e5271e&locator=javascript-modules-engine%40workspace%3A."
   dependencies:
+    dotenv: "npm:^16.4.7"
     graphql: "npm:^16.0.1"
     graphql-tag: "npm:^2.12.6"
     prop-types: "npm:^15.8.1"
@@ -1299,7 +1300,9 @@ __metadata:
       optional: true
     styled-jsx:
       optional: true
-  checksum: 10c0/5899a54137b102251184b691c8c72f0f168685da4f0da676e5369a143ccb2d9a21f012fbed50bafa1e032dde1b67a722a1e1525e69c4970be0eefd99b0b9a85c
+  bin:
+    jahia-deploy: bin/jahia-deploy.mjs
+  checksum: 10c0/241e3ca0bcc8c289f01548277263d023fe6c81215eed3464e47223ae434257ceb9e338fdbc24ca081bbe7504c5fa15c6c4b0324dbaefa673b7631039ca9abfb4
   languageName: node
   linkType: hard
 
@@ -2530,6 +2533,13 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10c0/c96bdccabe9d62ab6fea9399fdff04a66e6563c1d6fb3a3a063e8d53c3bb136ba63e84250bbf63d00086a769ad53aef92d2bd483f03f837fc97b71cbee6b2520
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.4.7":
+  version: 16.4.7
+  resolution: "dotenv@npm:16.4.7"
+  checksum: 10c0/be9f597e36a8daf834452daa1f4cc30e5375a5968f98f46d89b16b983c567398a330580c88395069a77473943c06b877d1ca25b4afafcdd6d4adb549e8293462
   languageName: node
   linkType: hard
 

--- a/javascript-modules-engine/yarn.lock
+++ b/javascript-modules-engine/yarn.lock
@@ -1277,7 +1277,7 @@ __metadata:
 
 "@jahia/javascript-modules-library@file:../javascript-modules-library/dist::locator=javascript-modules-engine%40workspace%3A.":
   version: 0.4.0-SNAPSHOT
-  resolution: "@jahia/javascript-modules-library@file:../javascript-modules-library/dist#../javascript-modules-library/dist::hash=e5271e&locator=javascript-modules-engine%40workspace%3A."
+  resolution: "@jahia/javascript-modules-library@file:../javascript-modules-library/dist#../javascript-modules-library/dist::hash=3d703a&locator=javascript-modules-engine%40workspace%3A."
   dependencies:
     dotenv: "npm:^16.4.7"
     graphql: "npm:^16.0.1"
@@ -1302,7 +1302,7 @@ __metadata:
       optional: true
   bin:
     jahia-deploy: bin/jahia-deploy.mjs
-  checksum: 10c0/241e3ca0bcc8c289f01548277263d023fe6c81215eed3464e47223ae434257ceb9e338fdbc24ca081bbe7504c5fa15c6c4b0324dbaefa673b7631039ca9abfb4
+  checksum: 10c0/afe30647aa916a2053d36eb6c8ae5143315f7a0e929017e1fa445a2ccf5e97a52f5d23739cfea0104f7ca2821a668e4ee687f594087ed8bd442493f2b21ffb6b
   languageName: node
   linkType: hard
 

--- a/javascript-modules-library/package.json
+++ b/javascript-modules-library/package.json
@@ -7,10 +7,10 @@
   "license": "MIT",
   "scripts": {
     "types:copy": "mkdir -p dist/types && ncp target/types dist/types",
-    "build:development": "run types:copy && tsc && node generate-index.js",
+    "build:development": "run types:copy && tsc && node generate-index",
     "build:production": "run build:development && run minify",
     "build": "run build:production",
-    "minify": "node minify.js",
+    "minify": "node minify",
     "doc": "typedoc",
     "clean": "rm -rf dist",
     "lint": "eslint --ext js,jsx,json,ts src/",

--- a/javascript-modules-library/package.json
+++ b/javascript-modules-library/package.json
@@ -7,20 +7,24 @@
   "license": "MIT",
   "scripts": {
     "types:copy": "mkdir -p dist/types && ncp target/types dist/types",
-    "build:development": "run types:copy && tsc && node generate-index",
+    "build:development": "run types:copy && tsc && node generate-index.js",
     "build:production": "run build:development && run minify",
     "build": "run build:production",
-    "minify": "node minify",
+    "minify": "node minify.js",
     "doc": "typedoc",
     "clean": "rm -rf dist",
     "lint": "eslint --ext js,jsx,json,ts src/",
     "lint:fix": "eslint --ext js,jsx,json,ts --fix src/",
     "prepack": "echo 'Please run 'mvn package' to create the tgz so the Maven version can be injected in the package.json' && exit 1"
   },
+  "bin": {
+    "jahia-deploy": "bin/jahia-deploy.mjs"
+  },
   "files": [
     "dist"
   ],
   "dependencies": {
+    "dotenv": "^16.4.7",
     "graphql": "^16.0.1",
     "graphql-tag": "^2.12.6",
     "prop-types": "^15.8.1"

--- a/javascript-modules-library/src/bin/jahia-deploy.mjs
+++ b/javascript-modules-library/src/bin/jahia-deploy.mjs
@@ -1,0 +1,27 @@
+import dotenv from 'dotenv';
+import {execSync} from 'child_process';
+import path from 'path';
+
+dotenv.config();
+
+const deployMethod = process.env.JAHIA_DEPLOY_METHOD;
+
+const packageFilePath = path.resolve('dist/package.tgz');
+
+if (deployMethod === 'curl') {
+    console.log('Deploying URL curl to Jahia bundles REST API...');
+    console.log(
+        execSync(
+            `curl -s --user ${process.env.JAHIA_USER} --form bundle=@${packageFilePath} --form start=true ${process.env.JAHIA_HOST}/modules/api/bundles`,
+            {encoding: 'utf8'}
+        )
+    );
+} else {
+    console.log('Deploying using Docker copy...');
+    console.log(
+        execSync(
+            `docker cp ${packageFilePath} ${process.env.JAHIA_DOCKER_NAME}:/var/jahia/modules`,
+            {encoding: 'utf8'}
+        )
+    );
+}

--- a/javascript-modules-library/tsconfig.json
+++ b/javascript-modules-library/tsconfig.json
@@ -26,7 +26,8 @@
          },
     },
     "include": [
-        "src/**/*.js",
+       "src/**/*.js",
+       "src/**/*.mjs"
     ],
     "exclude": [
         "node_modules",

--- a/javascript-modules-library/yarn.lock
+++ b/javascript-modules-library/yarn.lock
@@ -1654,6 +1654,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^4.29.3"
     babel-loader: "npm:^9.1.3"
     babel-plugin-transform-react-jsx: "npm:^6.24.1"
+    dotenv: "npm:^16.4.7"
     eslint: "npm:^7.32.0"
     eslint-plugin-cypress: "npm:^2.11.3"
     eslint-plugin-jest: "npm:^27.2.1"
@@ -1688,6 +1689,8 @@ __metadata:
       optional: true
     styled-jsx:
       optional: true
+  bin:
+    jahia-deploy: bin/jahia-deploy.mjs
   languageName: unknown
   linkType: soft
 
@@ -2825,6 +2828,13 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10c0/c96bdccabe9d62ab6fea9399fdff04a66e6563c1d6fb3a3a063e8d53c3bb136ba63e84250bbf63d00086a769ad53aef92d2bd483f03f837fc97b71cbee6b2520
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.4.7":
+  version: 16.4.7
+  resolution: "dotenv@npm:16.4.7"
+  checksum: 10c0/be9f597e36a8daf834452daa1f4cc30e5375a5968f98f46d89b16b983c567398a330580c88395069a77473943c06b877d1ca25b4afafcdd6d4adb549e8293462
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Copy the build scripts (to ~compile, clean, build, pack,~ deploy ~and watch~) from https://github.com/Jahia/javascript-components/ to this repository, so the project can get rid of the dependency towards `@jahia/scripts dependency`.
Example of cleanup in Luxe: https://github.com/Jahia/luxe-jahia-demo/pull/178

When the `@jahia/javascript-modules-library` dependency is added to a project, the following commands are exposed:
- ~`jahia-build` : simply calls the production build (`jahia-build_production`)~
-  ~`jahia-build_development`: builds the project with webpack using the _development_ mode~
- ~`jahia-build_production`: builds the project with webpack default mode (_production_)~
- ~`jahia-clean`: cleans the generated folder created by the build (`dist/`)~
- `jahia-deploy`: builds the project if needed, then deploys the `.tgz` file to a running Jahia instance (via Docker or curl)
- ~`jahia-watch`: watches for changes and automatically build and deploy them to a running Jahia instance~

