### PR TITLE
build: refactor frontend plugin and bump node/yarn/npm versions

### DIFF
--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -38,8 +38,6 @@
             org.jahia.modules.graphql.provider.dxm.osgi.annotations;version="[2.7,4)",
             org.jahia.modules.graphql.provider.dxm.util;version="[2.7,4)",
         </import-package>
-        <frontend-maven-plugin.nodeVersion>v18.12.0</frontend-maven-plugin.nodeVersion>
-        <frontend-maven-plugin.yarnVersion>v1.22.19</frontend-maven-plugin.yarnVersion>
         <require-capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version&gt;=17))"</require-capability>
         <!--  Since React 19 and new JSX transformation, in production, all other jsmodules should be production  -->
         <!--  To get a full compatibility, we use dev mode by default  -->
@@ -195,7 +193,6 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.12.1</version>
                 <configuration>
                     <environmentVariables>
                         <NODE_OPTIONS>--openssl-legacy-provider</NODE_OPTIONS>
@@ -208,10 +205,6 @@
                         <goals>
                             <goal>install-node-and-yarn</goal>
                         </goals>
-                        <configuration>
-                            <nodeVersion>${frontend-maven-plugin.nodeVersion}</nodeVersion>
-                            <yarnVersion>${frontend-maven-plugin.yarnVersion}</yarnVersion>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>yarn install</id>

--- a/javascript-modules-library/pom.xml
+++ b/javascript-modules-library/pom.xml
@@ -10,13 +10,6 @@
     <packaging>pom</packaging>
     <description>Javascript library (wrapped as a Maven project) used to build Javascript modules that run on Jahia.</description>
 
-    <properties>
-        <node.version>v22.10.0</node.version>
-        <!-- frontend-maven-plugin requires to use yarn 1.22.x as a "bootstrap" but then, the .yarnrc.yml will be detected and Yarn Berry (4+) will be used -->
-        <yarn.version>v1.22.19</yarn.version>
-        <npm.version>10.9.0</npm.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -25,15 +18,6 @@
         </dependency>
     </dependencies>
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>com.github.eirslett</groupId>
-                    <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.15.1</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -77,11 +61,6 @@
                             <goal>install-node-and-yarn</goal>
                             <goal>install-node-and-npm</goal>
                         </goals>
-                        <configuration>
-                            <nodeVersion>${node.version}</nodeVersion>
-                            <yarnVersion>${yarn.version}</yarnVersion>
-                            <npmVersion>${npm.version}</npmVersion>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>yarn install</id>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
         <graalvm.sdk.version>23.0.2</graalvm.sdk.version>
         <!-- override the version of org.sonatype.plugins:nexus-staging-maven-plugin to ensure compatibility with JDK 17 -->
         <nexus.maven.plugin.version>1.7.0</nexus.maven.plugin.version>
+        <!-- frontend-maven-plugin requires to use yarn 1.22.x as a "bootstrap" but then, the .yarnrc.yml will be detected and Yarn Berry (4+) will be used -->
+        <frontend-maven-plugin.yarn.version>v1.22.22</frontend-maven-plugin.yarn.version>
+        <frontend-maven-plugin.node.version>v22.10.0</frontend-maven-plugin.node.version>
+        <frontend-maven-plugin.npm.version>11.1.0</frontend-maven-plugin.npm.version>
     </properties>
 
     <repositories>
@@ -68,6 +72,16 @@
         <pluginManagement>
             <!-- define plugins versions not set in parent pom -->
             <plugins>
+                <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <version>1.15.1</version>
+                    <configuration>
+                        <nodeVersion>${frontend-maven-plugin.node.version}</nodeVersion>
+                        <yarnVersion>${frontend-maven-plugin.yarn.version}</yarnVersion>
+                        <npmVersion>${frontend-maven-plugin.npm.version}</npmVersion>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Refactor the usage of the Maven plugin _com.github.eirslett:frontend-maven-plugin_ to centralize its configuration.
Bump versions:
- `yarn` to 1.22.22
- `node` to 22.10.0
- `npm` to 11.1.0
