### PR TITLE
fix: AddContentButtons now takes a list of nodeTypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-# Intellij
+# OS/IDE junk
+.DS_Store
 .idea
 *.iml
 

--- a/jahia-test-module/src/react/server/views/testRender/TestRender.jsx
+++ b/jahia-test-module/src/react/server/views/testRender/TestRender.jsx
@@ -52,7 +52,7 @@ export const TestRender = () => {
       Render a text child node :
       <div data-testid="component-text-child-node" className="case">
         <Render path={"simpletext"} />
-        <AddContentButtons childName={"simpletext"} nodeTypes={"jnt:text"} />
+        <AddContentButtons childName={"simpletext"} nodeTypes={["jnt:text"]} />
       </div>
       Render a JSON Node with mixins :
       <div data-testid="component-json-node-with-mixin" className="case">

--- a/javascript-modules-library/src/core/server/components/AddContentButtons.tsx
+++ b/javascript-modules-library/src/core/server/components/AddContentButtons.tsx
@@ -3,28 +3,74 @@ import { server } from "@jahia/javascript-modules-library-private";
 import { useServerContext } from "../hooks/useServerContext.js";
 
 /**
+ * React best practices: use a variable instead of an expression so that React can optimize the
+ * rendering safely.
+ *
+ * This is because `[] !== []` in JavaScript (arrays are compared by reference), so React might
+ * re-render the component.
+ *
+ * @see {@link https://eslint-react.xyz/docs/rules/no-unstable-default-props}
+ */
+const defaultNodeTypes: string[] = [];
+
+/**
  * Generates add content buttons for a content object
  *
  * @returns The add content buttons.
  */
+export function AddContentButtons(
+  props: Readonly<{
+    /** The node types to add. */
+    nodeTypes?: string[];
+    /**
+     * The child name.
+     *
+     * @default *
+     */
+    childName?: string;
+    /**
+     * If true, the edit check will be performed.
+     *
+     * @default false
+     */
+    editCheck?: boolean;
+  }>,
+): JSX.Element;
+/**
+ * Change nodeTypes="type1 type2 type3" to nodeTypes={["type1", "type2", "type3"]}
+ *
+ * @deprecated
+ */
+export function AddContentButtons(
+  props: Readonly<{
+    /**
+     * Change nodeTypes="type1 type2 type3" to nodeTypes={["type1", "type2", "type3"]}
+     *
+     * @deprecated
+     */
+    nodeTypes?: string;
+    /**
+     * The child name.
+     *
+     * @default *
+     */
+    childName?: string;
+    /**
+     * If true, the edit check will be performed.
+     *
+     * @default false
+     */
+    editCheck?: boolean;
+  }>,
+): JSX.Element;
+
 export function AddContentButtons({
-  nodeTypes = "",
+  nodeTypes = defaultNodeTypes,
   childName = "*",
   editCheck = false,
 }: Readonly<{
-  /** The node types to add. */
-  nodeTypes?: string;
-  /**
-   * The child name.
-   *
-   * @default *
-   */
+  nodeTypes?: string[] | string; // string is deprecated
   childName?: string;
-  /**
-   * If true, the edit check will be performed.
-   *
-   * @default false
-   */
   editCheck?: boolean;
 }>): JSX.Element {
   const { renderContext, currentResource } = useServerContext();
@@ -34,7 +80,10 @@ export function AddContentButtons({
       dangerouslySetInnerHTML={{
         __html: server.render.createContentButtons(
           childName,
-          nodeTypes,
+          // The render produces a ModuleTag instance under the hood
+          // (<template:module nodeTypes="type1 type2 type3" /> in JSP),
+          // it expects a string with the node types separated by a space.
+          Array.isArray(nodeTypes) ? nodeTypes.join(" ") : nodeTypes,
           editCheck,
           renderContext,
           currentResource,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Fixes #64: `<AddContentButtons>` now takes a list of types as its nodeTypes property `<AddContentButtons nodeTypes={['jnt:text', 'jnt:bigText']}>`

The previous signature (space-separated list) is still working but marked as `@deprecated`:

<img width="1239" alt="image" src="https://github.com/user-attachments/assets/353313c6-a743-4413-bb81-98915ff1bbbb" />


## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
