### PR TITLE
fix: expose react/jsx-runtime for ssr

### DIFF
--- a/javascript-modules-engine/src/javascript/library/init.js
+++ b/javascript-modules-engine/src/javascript/library/init.js
@@ -1,4 +1,5 @@
 import React from "react";
+import jsxRuntime from "react/jsx-runtime";
 import * as javascriptModulesLibrary from "@jahia/javascript-modules-library";
 import javascriptModulesLibraryBuilder from "@jahia/javascript-modules-library-builder";
 import * as ReactI18Next from "react-i18next";
@@ -12,6 +13,7 @@ export default () => {
   }
 
   javascriptModulesLibraryBuilder.addSharedLibrary("react", React);
+  javascriptModulesLibraryBuilder.addSharedLibrary("react/jsx-runtime", jsxRuntime);
   javascriptModulesLibraryBuilder.addSharedLibrary("react-i18next", ReactI18Next);
   javascriptModulesLibraryBuilder.addSharedLibrary("i18next", I18next);
   javascriptModulesLibraryBuilder.addSharedLibrary("styled-jsx", styledJsx);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

A minor oversight during #56: the JSX transform could not be used during server-side rendering (SSR) because it was not exposed by the library

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
