### PR TITLE
build: javascript-modules-library is now a pom dependency

### DIFF
--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -122,7 +122,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>javascript-modules-library</artifactId>
             <version>${project.version}</version>
-            <type>tgz</type>
+            <type>pom</type>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Declare _javascript-modules-library_ as a _pom_ dependency (as per the changes in https://github.com/Jahia/javascript-modules/pull/119) to fix the `mvn deploy`.

