### PR TITLE
ci: skip all workflows for upcoming documentation

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+    # Disable the workflow for doc-only changes
+    # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths
+    paths-ignore:
+      - "docs/**"
+
 jobs:
   static-analysis:
     name: Static Analysis (linting, vulns)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,8 +5,10 @@
 # See documentation here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only
-# modifies JS files, only @js-owner and not the global 
+# modifies JS files, only @js-owner and not the global
 # owner(s) will be requested for a review.
 
-*    @Jahia/team-goat
-/javascript-modules-engine/tests/ @Jahia/team-goat_qa @Jahia/team-goat
+* @Jahia/team-goat
+
+# Disable mandatory code review for WIP documentation
+/docs/


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Avoid wasting human and machine time for short iterations in the product team

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
