### PR TITLE
build: Remove installation of npm

### DIFF
--- a/javascript-create-module/pom.xml
+++ b/javascript-create-module/pom.xml
@@ -30,11 +30,10 @@
                 <executions>
                     <!-- Executions bound on the "initialize" phase (executed in order of declaration): -->
                     <execution>
-                        <id>install node, yarn and npm</id>
+                        <id>install node and yarn</id>
                         <phase>initialize</phase>
                         <goals>
                             <goal>install-node-and-yarn</goal>
-                            <goal>install-node-and-npm</goal>
                         </goals>
                     </execution>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <!-- frontend-maven-plugin requires to use yarn 1.22.x as a "bootstrap" but then, the .yarnrc.yml will be detected and Yarn Berry (4+) will be used -->
         <frontend-maven-plugin.yarn.version>v1.22.22</frontend-maven-plugin.yarn.version>
         <frontend-maven-plugin.node.version>v22.10.0</frontend-maven-plugin.node.version>
-        <frontend-maven-plugin.npm.version>11.1.0</frontend-maven-plugin.npm.version>
     </properties>
 
     <repositories>
@@ -81,7 +80,6 @@
                     <configuration>
                         <nodeVersion>${frontend-maven-plugin.node.version}</nodeVersion>
                         <yarnVersion>${frontend-maven-plugin.yarn.version}</yarnVersion>
-                        <npmVersion>${frontend-maven-plugin.npm.version}</npmVersion>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/vite-plugin/pom.xml
+++ b/vite-plugin/pom.xml
@@ -29,11 +29,10 @@
                 <executions>
                     <!-- Executions bound on the "initialize" phase (executed in order of declaration): -->
                     <execution>
-                        <id>install node, yarn and npm</id>
+                        <id>install node and yarn</id>
                         <phase>initialize</phase>
                         <goals>
                             <goal>install-node-and-yarn</goal>
-                            <goal>install-node-and-npm</goal>
                         </goals>
                     </execution>
                     <execution>


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
As the publication is done using a `yarn npm publish`, there is no need to install npm as part of the initialization phase.
This is similar to what is configured for the [_javascript-modules-libray_ module](https://github.com/Jahia/javascript-modules/blob/main/javascript-modules-library/pom.xml#L40).