### PR TITLE
feat(library)!: made attributes default to false

### DIFF
--- a/jahia-test-module/src/react/server/views/testAbsoluteAreas/TestAbsoluteAreas.tsx
+++ b/jahia-test-module/src/react/server/views/testAbsoluteAreas/TestAbsoluteAreas.tsx
@@ -52,7 +52,7 @@ jahiaComponent(
 
       <h2>Non editable area </h2>
       <div data-testid="nonEditableArea">
-        <AbsoluteArea name="nonEditable" editable={false} level={1} />
+        <AbsoluteArea name="nonEditable" readOnly level={1} />
       </div>
 
       <h2>Absolute area level </h2>
@@ -67,7 +67,7 @@ jahiaComponent(
 
       <h2>Limited absolute area editing</h2>
       <div data-testid="limitedAbsoluteAreaEdit">
-        <AbsoluteArea name="pagecontent" limitedAbsoluteAreaEdit={false} />
+        <AbsoluteArea name="pagecontent" readOnly="children" />
       </div>
 
       <h2>Absolute Area parameters</h2>

--- a/jahia-test-module/src/react/server/views/testAreas/TestAreas.tsx
+++ b/jahia-test-module/src/react/server/views/testAreas/TestAreas.tsx
@@ -43,7 +43,7 @@ jahiaComponent(
 
       <h2>Non editable area </h2>
       <div data-testid="nonEditableArea">
-        <Area name="nonEditable" editable={false} />
+        <Area name="nonEditable" readOnly />
       </div>
 
       <h2>Area as sub node </h2>

--- a/jahia-test-module/src/react/server/views/testRender/TestRenderEditable.tsx
+++ b/jahia-test-module/src/react/server/views/testRender/TestRenderEditable.tsx
@@ -25,7 +25,7 @@ jahiaComponent(
             {allChildren &&
               allChildren.map(function (child) {
                 return (
-                  <Render path={child.getPath()} editable={true} key={child.getIdentifier()} />
+                  <Render path={child.getPath()} key={child.getIdentifier()} />
                 );
               })}
           </div>
@@ -36,7 +36,7 @@ jahiaComponent(
             {allChildren &&
               allChildren.map(function (child) {
                 return (
-                  <Render path={child.getPath()} editable={false} key={child.getIdentifier()} />
+                  <Render path={child.getPath()} readOnly key={child.getIdentifier()} />
                 );
               })}
           </div>

--- a/javascript-modules-engine/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
+++ b/javascript-modules-engine/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
@@ -181,7 +181,7 @@ describe('Absolute Area test', () => {
         cy.login()
         cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
         cy.iframe('#page-builder-frame-1').within(() => {
-            cy.get('div[data-testid="limitedAbsoluteAreaEdit"]').find('div[type="existingNode"]').should('exist')
+            cy.get('div[data-testid="limitedAbsoluteAreaEdit"]').find('div[type="existingNode"]').should('not.exist')
         })
         cy.logout()
     })

--- a/javascript-modules-library/src/core/server/components/AbsoluteArea.tsx
+++ b/javascript-modules-library/src/core/server/components/AbsoluteArea.tsx
@@ -65,7 +65,7 @@ export function AbsoluteArea({
             numberOfItems,
             subNodesView,
             path,
-            editable: readOnly !== false,
+            editable: readOnly !== true,
             level,
             areaType,
             limitedAbsoluteAreaEdit: readOnly === "children",

--- a/javascript-modules-library/src/core/server/components/AbsoluteArea.tsx
+++ b/javascript-modules-library/src/core/server/components/AbsoluteArea.tsx
@@ -14,10 +14,9 @@ export function AbsoluteArea({
   numberOfItems,
   subNodesView,
   path,
-  editable = true,
+  readOnly = false,
   level,
   areaType = "jnt:contentList",
-  limitedAbsoluteAreaEdit,
   parameters,
 }: Readonly<{
   /** The name of the area. */
@@ -33,12 +32,15 @@ export function AbsoluteArea({
   /** Relative (to the current node) or absolute path to the node to include. */
   path?: string;
   /**
-   * Enables or disables edition of this content in edit mode. Mainly used for absolute or
-   * references.
+   * Makes the area read-only.
    *
-   * @default true
+   * - When set to `false` (default), the area is editable on all pages.
+   * - When set to `true`, the area is read-only on all pages.
+   * - When set to `"children"`, the area is read-only on all pages except the one containing its node.
+   *
+   * @default false
    */
-  editable?: boolean;
+  readOnly?: boolean | "children"
   /** Ancestor level for absolute area - 0 is Home page, 1 first sub-pages, ... */
   level?: number;
   /**
@@ -47,8 +49,6 @@ export function AbsoluteArea({
    * @default jnt:contentList
    */
   areaType?: string;
-  /** Is the absolute area editable everywhere or only on the page containing its node. */
-  limitedAbsoluteAreaEdit?: boolean;
   /** The parameters to pass to the absolute area */
   parameters?: Record<string, unknown>;
 }>): React.JSX.Element {
@@ -65,10 +65,10 @@ export function AbsoluteArea({
             numberOfItems,
             subNodesView,
             path,
-            editable,
+            editable: readOnly !== false,
             level,
             areaType,
-            limitedAbsoluteAreaEdit,
+            limitedAbsoluteAreaEdit: readOnly === "children",
             parameters,
           },
           renderContext,

--- a/javascript-modules-library/src/core/server/components/Area.tsx
+++ b/javascript-modules-library/src/core/server/components/Area.tsx
@@ -14,7 +14,7 @@ export function Area({
   numberOfItems,
   subNodesView,
   path,
-  editable = true,
+  readOnly = false,
   areaAsSubNode,
   areaType = "jnt:contentList",
   parameters,
@@ -32,12 +32,11 @@ export function Area({
   /** Relative (to the current node) or absolute path to the node to include. */
   path?: string;
   /**
-   * Enables or disables edition of this content in edit mode. Mainly used for absolute or
-   * references.
+   * Makes the area read-only.
    *
-   * @default true
+   * @default false
    */
-  editable?: boolean;
+  readOnly?: boolean;
   /** Allow area to be stored as a subnode */
   areaAsSubNode?: boolean;
   /**
@@ -62,7 +61,7 @@ export function Area({
             numberOfItems,
             subNodesView,
             path,
-            editable,
+            editable: !readOnly,
             areaAsSubNode,
             areaType,
             parameters,

--- a/javascript-modules-library/src/core/server/components/render/Render.tsx
+++ b/javascript-modules-library/src/core/server/components/render/Render.tsx
@@ -11,7 +11,7 @@ export function Render({
   content,
   node,
   path,
-  editable = true,
+  readOnly = false,
   advanceRenderingConfig,
   templateType,
   view,
@@ -24,11 +24,11 @@ export function Render({
   /** The path to render */
   path?: string;
   /**
-   * If the content should be editable
+   * Makes the child read-only.
    *
-   * @default true
+   * @default false
    */
-  editable?: boolean;
+  readOnly?: boolean;
   /**
    * Specifies if we should render a node or simply include a view. Acceptable values are : none,
    * INCLUDE or OPTION
@@ -51,7 +51,7 @@ export function Render({
             content,
             node,
             path,
-            editable,
+            editable: !readOnly,
             advanceRenderingConfig,
             templateType,
             view,


### PR DESCRIPTION
### Description

Breaking change!

All attributes now default to false: instead of writing `<Area editable={false}>` you'd write `<Area readOnly>`

Closes #180 

### Checklist
#### Source code
- [ ] I've considered the implications on security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] I've considered the implications on performances
- [ ] I've considered the implications on migration
- [ ] I've considered the implications on code maintainability

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

#### Documentation
- [ ] I've provided inline documentation (Source code)
- [ ] I've provided internal documentation (README, Confluence)
- [ ] I've provided user-facing documentation (Academy)

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
