### PR TITLE
feat!: Refactor <Area> and <ContentArea> components

### DIFF
--- a/jahia-test-module/src/react/server/views/testAbsoluteAreas/TestAbsoluteAreas.tsx
+++ b/jahia-test-module/src/react/server/views/testAbsoluteAreas/TestAbsoluteAreas.tsx
@@ -7,79 +7,81 @@ jahiaComponent(
     displayName: "Test Absolute Areas (react)",
     componentType: "view",
   },
-  () => (
+  (_, { currentNode, renderContext }) => (
     <>
       <h2>React JAbsoluteArea test component</h2>
 
       <h2>Basic Area</h2>
       <div data-testid="basicArea">
-        <AbsoluteArea name={"basicArea"} level={1} />
+        <AbsoluteArea name={"basicArea"} parent={currentNode} />
       </div>
 
       <h2>Area with allowed types</h2>
       <div data-testid="allowedTypesArea">
         <AbsoluteArea
           name={"allowedTypesArea"}
-          allowedTypes={["jnt:event", "jnt:bigText"]}
-          level={1}
+          parent={currentNode}
+          allowedNodeTypes={["jnt:event", "jnt:bigText"]}
         />
       </div>
 
       <h2>Area with number of items</h2>
       <div data-testid="numberOfItemsArea">
-        <AbsoluteArea name={"numberOfItemsArea"} numberOfItems={2} level={1} />
+        <AbsoluteArea name={"numberOfItemsArea"} parent={currentNode} numberOfItems={2} />
       </div>
 
       <h2>Area with areaView</h2>
       <div data-testid="areaViewArea">
-        <AbsoluteArea name={"areaViewArea"} areaView={"dropdown"} level={1} />
+        <AbsoluteArea name={"areaViewArea"} parent={currentNode} view={"dropdown"} />
       </div>
 
-      <h2>Area with subNodesView</h2>
-      <div data-testid="subNodesViewArea">
-        <AbsoluteArea name={"subNodesViewArea"} subNodesView={"link"} level={1} />
+      <h2>Area with parent</h2>
+      <div data-testid="parentArea">
+        <AbsoluteArea name="subLevel" parent={currentNode.getNode("basicArea")} />
       </div>
 
-      <h2>Area with path</h2>
-      <div data-testid="pathArea">
-        <AbsoluteArea path={"basicArea/subLevel"} level={1} />
+      <h2>Absolute Area with home page</h2>
+      <div data-testid="absoluteAreaHomePage">
+        <AbsoluteArea name="pagecontent" parent={renderContext.getSite().getHome()} />
       </div>
 
-      <h2>Absolute Area with home page content</h2>
-      <div data-testid="absoluteArea">
-        <AbsoluteArea name="pagecontent" />
+      <h2>Absolute Area with custom page (sub-level)</h2>
+      <div data-testid="absoluteAreaCustomPage">
+        <AbsoluteArea
+          name="pagecontent"
+          parent={renderContext.getSite().getNode("custom/sub-level")}
+        />
       </div>
 
       <h2>Non editable area </h2>
       <div data-testid="nonEditableArea">
-        <AbsoluteArea name="nonEditable" readOnly level={1} />
-      </div>
-
-      <h2>Absolute area level </h2>
-      <div data-testid="absoluteAreaLevel">
-        <AbsoluteArea name="pagecontent" level={0} />
+        <AbsoluteArea name="nonEditable" parent={currentNode} readOnly />
       </div>
 
       <h2>Area type</h2>
       <div data-testid="areaType">
-        <AbsoluteArea name="areaType" areaType="javascriptExample:testAreaColumns" level={1} />
+        <AbsoluteArea
+          name="areaType"
+          parent={currentNode}
+          nodeType="javascriptExample:testAreaColumns"
+        />
       </div>
 
       <h2>Limited absolute area editing</h2>
       <div data-testid="limitedAbsoluteAreaEdit">
-        <AbsoluteArea name="pagecontent" readOnly="children" />
+        <AbsoluteArea name="pagecontent" parent={currentNode} readOnly="children" />
       </div>
 
       <h2>Absolute Area parameters</h2>
       <div data-testid="absoluteAreaParameters">
         <AbsoluteArea
           name="absoluteAreaParameters"
-          areaView="parameters"
+          parent={currentNode}
+          view="parameters"
           parameters={{
             stringParam1: "stringValue1",
             stringParam2: "stringValue2",
           }}
-          level={1}
         />
       </div>
     </>

--- a/jahia-test-module/src/react/server/views/testAreaColumns/TestAreaColumns.tsx
+++ b/jahia-test-module/src/react/server/views/testAreaColumns/TestAreaColumns.tsx
@@ -10,10 +10,10 @@ jahiaComponent(
     return (
       <div data-testid={`row-${currentNode.getName()}`}>
         <div data-testid={`${currentNode.getName()}-col-1`}>
-          <Area name={`${currentNode.getName()}-col-1`} areaAsSubNode={true} />
+          <Area name={`${currentNode.getName()}-col-1`} />
         </div>
         <div data-testid={`${currentNode.getName()}-col-2`}>
-          <Area name={`${currentNode.getName()}-col-2`} areaAsSubNode={true} />
+          <Area name={`${currentNode.getName()}-col-2`} />
         </div>
       </div>
     );

--- a/jahia-test-module/src/react/server/views/testAreas/TestAreas.tsx
+++ b/jahia-test-module/src/react/server/views/testAreas/TestAreas.tsx
@@ -18,7 +18,7 @@ jahiaComponent(
 
       <h2>Area with allowed types</h2>
       <div data-testid="allowedTypesArea">
-        <Area name={"allowedTypesArea"} allowedTypes={["jnt:event", "jnt:bigText"]} />
+        <Area name={"allowedTypesArea"} allowedNodeTypes={["jnt:event", "jnt:bigText"]} />
       </div>
 
       <h2>Area with number of items</h2>
@@ -28,17 +28,12 @@ jahiaComponent(
 
       <h2>Area with areaView</h2>
       <div data-testid="areaViewArea">
-        <Area name={"areaViewArea"} areaView={"dropdown"} />
-      </div>
-
-      <h2>Area with subNodesView</h2>
-      <div data-testid="subNodesViewArea">
-        <Area name={"subNodesViewArea"} subNodesView={"link"} />
+        <Area name={"areaViewArea"} view={"dropdown"} />
       </div>
 
       <h2>Area with path</h2>
-      <div data-testid="pathArea">
-        <Area path={"basicArea/subLevel"} />
+      <div data-testid="parentArea">
+        <Area name={"basicArea/subLevel"} />
       </div>
 
       <h2>Non editable area </h2>
@@ -46,21 +41,16 @@ jahiaComponent(
         <Area name="nonEditable" readOnly />
       </div>
 
-      <h2>Area as sub node </h2>
-      <div data-testid="areaAsSubNode">
-        <Area name="areaAsSubNode" areaAsSubNode={true} />
-      </div>
-
       <h2>Area type</h2>
       <div data-testid="areaType">
-        <Area name="areaType" areaType="javascriptExample:testAreaColumns" />
+        <Area name="areaType" nodeType="javascriptExample:testAreaColumns" />
       </div>
 
       <h2>Area parameters</h2>
       <div data-testid="areaParameters">
         <Area
           name="areaParameters"
-          areaView="parameters"
+          view="parameters"
           parameters={{
             stringParam1: "stringValue1",
             stringParam2: "stringValue2",

--- a/javascript-modules-engine-java/.java-ts-bind/package.json
+++ b/javascript-modules-engine-java/.java-ts-bind/package.json
@@ -237,6 +237,7 @@
       "org.jahia.modules.javascript.modules.engine.js.server.OSGiHelper.*",
       "org.jahia.modules.javascript.modules.engine.js.server.RegistryHelper.*",
       "org.jahia.modules.javascript.modules.engine.js.server.RenderHelper.*",
+      "org.jahia.services.content.decorator.JCRNodeDecorator.getNode.*",
       "org.jahia.services.content.JCRCallback.*",
       "org.jahia.services.content.JCRItemWrapper.get.*",
       "org.jahia.services.content.JCRItemWrapper.is.*",

--- a/javascript-modules-engine-java/pom.xml
+++ b/javascript-modules-engine-java/pom.xml
@@ -101,6 +101,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelper.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelper.java
@@ -49,7 +49,6 @@ import javax.servlet.jsp.tagext.BodyTagSupport;
 import javax.servlet.jsp.tagext.TagSupport;
 import java.io.IOException;
 import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URLDecoder;
 import java.util.*;
@@ -60,9 +59,8 @@ import java.util.stream.Collectors;
  */
 public class RenderHelper {
     private static final Logger logger = LoggerFactory.getLogger(RenderHelper.class);
-
-    private static final Set<String> ABSOLUTEAREA_ALLOWED_ATTRIBUTES = Set.of("name", "path", "areaView", "allowedTypes", "numberOfItems", "subNodesView", "editable", "areaType", "level", "limitedAbsoluteAreaEdit", "parameters");
-    private static final Set<String> AREA_ALLOWED_ATTRIBUTES = Set.of("name", "path", "areaView", "allowedTypes", "numberOfItems", "subNodesView", "editable", "areaAsSubNode", "areaType", "parameters");
+    private static final Set<String> ABSOLUTEAREA_ALLOWED_ATTRIBUTES = Set.of("name", "parent", "view", "allowedNodeTypes", "numberOfItems", "nodeType", "editable", "areaType", "limitedAbsoluteAreaEdit", "parameters");
+    private static final Set<String> AREA_ALLOWED_ATTRIBUTES = Set.of("name", "view", "allowedNodeTypes", "numberOfItems", "nodeType", "editable", "parameters");
 
     private JCRSessionFactory jcrSessionFactory;
     private JCRTemplate jcrTemplate;
@@ -80,6 +78,7 @@ public class RenderHelper {
 
     /**
      * Get the render parameters for the given resource
+     *
      * @param resource the resource for which to retrieve the render parameters
      * @return a Map&lt;String,Object&gt; containing the render parameters
      */
@@ -93,6 +92,7 @@ public class RenderHelper {
      * don't need encoding are those defined 'unreserved' in section 2.3 of
      * the 'URI generic syntax' RFC 2396. Not the entire path string is escaped,
      * but every individual part (i.e. the slashes are not escaped).
+     *
      * @param path the path to encode
      * @return a String containing the escaped path
      * @throws NullPointerException if <code>path</code> is <code>null</code>.
@@ -104,9 +104,10 @@ public class RenderHelper {
     /**
      * Find the first displayable node in the given node's hierarchy. A displayable node is a node that has a content
      * or page template associated with it.
-     * @param node the node at which to start the resolution
+     *
+     * @param node          the node at which to start the resolution
      * @param renderContext the current render context
-     * @param contextSite the site in which to resolve the template
+     * @param contextSite   the site in which to resolve the template
      * @return the first displayable {@link JCRNodeWrapper} found in the hierarchy
      */
     public JCRNodeWrapper findDisplayableNode(JCRNodeWrapper node, RenderContext renderContext, @Nullable JCRSiteNode contextSite) {
@@ -115,7 +116,8 @@ public class RenderHelper {
 
     /**
      * Returns the node which corresponds to the bound component of the j:bindedComponent property in the specified node.
-     * @param node the node to get the bound component for
+     *
+     * @param node    the node to get the bound component for
      * @param context current render context
      * @return the bound {@link JCRNodeWrapper}
      */
@@ -132,48 +134,48 @@ public class RenderHelper {
         return jcrTemplate.doExecuteWithSystemSessionAsUser(user, renderContext.getWorkspace(),
                 renderContext.getMainResource().getLocale(), session -> {
 
-            JCRNodeWrapper node = JSNodeMapper.toVirtualNode((Map<String, ?>) attr.get("content"), session, renderContext);
-            String renderConfig = attr.get("advanceRenderingConfig") != null ? (String) attr.get("advanceRenderingConfig") : "";
-            String templateType = attr.get("templateType") != null ? (String) attr.get("templateType") : "html";
+                    JCRNodeWrapper node = JSNodeMapper.toVirtualNode((Map<String, ?>) attr.get("content"), session, renderContext);
+                    String renderConfig = attr.get("advanceRenderingConfig") != null ? (String) attr.get("advanceRenderingConfig") : "";
+                    String templateType = attr.get("templateType") != null ? (String) attr.get("templateType") : "html";
 
-            if ("OPTION".equals(renderConfig)) {
-                Map<String, Object> optionAttr = new HashMap<>();
-                optionAttr.put("node", node);
-                optionAttr.put("templateType", templateType);
-                optionAttr.put("view", attr.get("view"));
-                optionAttr.put("parameters", attr.get("parameters"));
-                optionAttr.put("nodetype", node.getPrimaryNodeType().getName());
-                try {
-                    return renderTag(new OptionTag(), optionAttr, renderContext);
-                } catch (IllegalAccessException | InvocationTargetException | JspException | IOException e) {
-                    throw new RepositoryException(e);
-                }
-            } else {
-                Resource r = new Resource(node, templateType, (String) attr.get("view"),
-                        "INCLUDE".equals(renderConfig) ? "include" : "module");
-                // TODO TECH-1335 use TO_CACHE_WITH_PARENT_FRAGMENT constant once minimal jahia version >= 8.2.0.0
-                r.getModuleParams().put("toCacheWithParentFragment", true);
+                    if ("OPTION".equals(renderConfig)) {
+                        Map<String, Object> optionAttr = new HashMap<>();
+                        optionAttr.put("node", node);
+                        optionAttr.put("templateType", templateType);
+                        optionAttr.put("view", attr.get("view"));
+                        optionAttr.put("parameters", attr.get("parameters"));
+                        optionAttr.put("nodetype", node.getPrimaryNodeType().getName());
+                        try {
+                            return renderTag(new OptionTag(), optionAttr, renderContext);
+                        } catch (IllegalAccessException | InvocationTargetException | JspException | IOException e) {
+                            throw new RepositoryException(e);
+                        }
+                    } else {
+                        Resource r = new Resource(node, templateType, (String) attr.get("view"),
+                                "INCLUDE".equals(renderConfig) ? "include" : "module");
+                        // TODO TECH-1335 use TO_CACHE_WITH_PARENT_FRAGMENT constant once minimal jahia version >= 8.2.0.0
+                        r.getModuleParams().put("toCacheWithParentFragment", true);
 
-                try {
-                    // handle render parameters for JSON rendering
-                    Map<String, Object> renderParameters = (Map<String, Object>) attr.get("parameters");
-                    if (renderParameters != null && !renderParameters.isEmpty()) {
-                        String charset = renderContext.getResponse().getCharacterEncoding();
-                        for (Map.Entry<String, Object> renderParam : renderParameters.entrySet()) {
-                            // only allow String params for compatibility reasons due to JSP ParamParent parameters being a <String,String> map
-                            if (renderParam.getValue() instanceof String) {
-                                r.getModuleParams().put(URLDecoder.decode(renderParam.getKey(), charset),
-                                        URLDecoder.decode((String) renderParam.getValue(), charset));
+                        try {
+                            // handle render parameters for JSON rendering
+                            Map<String, Object> renderParameters = (Map<String, Object>) attr.get("parameters");
+                            if (renderParameters != null && !renderParameters.isEmpty()) {
+                                String charset = renderContext.getResponse().getCharacterEncoding();
+                                for (Map.Entry<String, Object> renderParam : renderParameters.entrySet()) {
+                                    // only allow String params for compatibility reasons due to JSP ParamParent parameters being a <String,String> map
+                                    if (renderParam.getValue() instanceof String) {
+                                        r.getModuleParams().put(URLDecoder.decode(renderParam.getKey(), charset),
+                                                URLDecoder.decode((String) renderParam.getValue(), charset));
+                                    }
+                                }
                             }
+
+                            return renderService.render(r, renderContext);
+                        } catch (RenderException | IOException e) {
+                            throw new RepositoryException(e);
                         }
                     }
-
-                    return renderService.render(r, renderContext);
-                } catch (RenderException | IOException e) {
-                    throw new RepositoryException(e);
-                }
-            }
-        });
+                });
     }
 
     public String createContentButtons(String childName, String nodeTypes, boolean editCheck, RenderContext renderContext, Resource currentResource) throws JspException, InvocationTargetException, IllegalAccessException, RepositoryException, IOException {
@@ -227,49 +229,50 @@ public class RenderHelper {
 
     /**
      * Render a tag that adds resources to the page. Resources might for example be CSS files, Javascript files or inline
-     * @param attr may contain the following:
-     *             <ul>
-     *             <li> insert (boolean) : If true, the resource will be inserted into the document. Typically used
-     *             for on-demand loading of resources. </li>
-     *             <li> async (boolean) : If true, the resource will be loaded asynchronously. For scripts, this means
-     *             the script
-     *             will be executed as soon as it's available, without blocking the rest of the page. </li>
-     *             <li> defer (boolean) : If true, the resource will be deferred, i.e., loaded after the document
-     *             has been parsed.
-     *             For scripts, this means the script will not be executed until after the page has loaded. </li>
-     *             <li> type (string) : The type of the resource. This could be 'javascript' for .js files, 'css' for
-     *             .css files, etc.
-     *             The type will be used to resolve the directory in the module where the resources are located. For example
-     *             for the 'css' type it will look for the resources in the css directory of the module. </li>
-     *             <li> resources (string) : The path to the resource file, relative to the module. It is also allowed to
-     *             specify multiple resources by separating them with commas. It is also allowed to use absolute URLs to
-     *             include remote resources. </li>
-     *             <li> inlineResource (string) : Inline HTML that markup will be considered as a resource. </li>
-     *             <li> title (string) : The title of the resource. This is typically not used for scripts or stylesheets,
-     *             but may be used for other types of resources. </li>
-     *             <li> key (string) : A unique key for the resource. This could be used to prevent duplicate resources
-     *             from being added to the document. </li>
-     *             <li> targetTag (string): The HTML tag where the resource should be added. This could be 'head' for
-     *             resources that should be added to the &lt;head&gt; tag, 'body' for resources that should be added to
-     *             the &lt;body&gt; tag, etc.</li>
-     *             <li> rel (string) : The relationship of the resource to the document. This is typically 'stylesheet'
-     *             for CSS files. </li>
-     *             <li> media (string) : The media for which the resource is intended. This is typically used for CSS
-     *             files, with values like 'screen', 'print', etc. </li>
-     *             <li> condition (string) : A condition that must be met for the resource to be loaded. This could be
-     *             used for conditional comments in IE, for example.</li>
-     *             </ul>
+     *
+     * @param attr          may contain the following:
+     *                      <ul>
+     *                      <li> insert (boolean) : If true, the resource will be inserted into the document. Typically used
+     *                      for on-demand loading of resources. </li>
+     *                      <li> async (boolean) : If true, the resource will be loaded asynchronously. For scripts, this means
+     *                      the script
+     *                      will be executed as soon as it's available, without blocking the rest of the page. </li>
+     *                      <li> defer (boolean) : If true, the resource will be deferred, i.e., loaded after the document
+     *                      has been parsed.
+     *                      For scripts, this means the script will not be executed until after the page has loaded. </li>
+     *                      <li> type (string) : The type of the resource. This could be 'javascript' for .js files, 'css' for
+     *                      .css files, etc.
+     *                      The type will be used to resolve the directory in the module where the resources are located. For example
+     *                      for the 'css' type it will look for the resources in the css directory of the module. </li>
+     *                      <li> resources (string) : The path to the resource file, relative to the module. It is also allowed to
+     *                      specify multiple resources by separating them with commas. It is also allowed to use absolute URLs to
+     *                      include remote resources. </li>
+     *                      <li> inlineResource (string) : Inline HTML that markup will be considered as a resource. </li>
+     *                      <li> title (string) : The title of the resource. This is typically not used for scripts or stylesheets,
+     *                      but may be used for other types of resources. </li>
+     *                      <li> key (string) : A unique key for the resource. This could be used to prevent duplicate resources
+     *                      from being added to the document. </li>
+     *                      <li> targetTag (string): The HTML tag where the resource should be added. This could be 'head' for
+     *                      resources that should be added to the &lt;head&gt; tag, 'body' for resources that should be added to
+     *                      the &lt;body&gt; tag, etc.</li>
+     *                      <li> rel (string) : The relationship of the resource to the document. This is typically 'stylesheet'
+     *                      for CSS files. </li>
+     *                      <li> media (string) : The media for which the resource is intended. This is typically used for CSS
+     *                      files, with values like 'screen', 'print', etc. </li>
+     *                      <li> condition (string) : A condition that must be met for the resource to be loaded. This could be
+     *                      used for conditional comments in IE, for example.</li>
+     *                      </ul>
      * @param renderContext the current rendering context
      * @return a String containing the rendered HTML tags for the provided resources.
-     * @throws IllegalAccessException if the underlying tag cannot be accessed
+     * @throws IllegalAccessException    if the underlying tag cannot be accessed
      * @throws InvocationTargetException if the underlying tag cannot be invoked
-     * @throws JspException if the underlying tag throws a JSP exception
-     * @throws IOException if the underlying tag throws an IO exception
+     * @throws JspException              if the underlying tag throws a JSP exception
+     * @throws IOException               if the underlying tag throws an IO exception
      */
     public String addResources(Map<String, Object> attr, RenderContext renderContext) throws IllegalAccessException, InvocationTargetException, JspException, IOException {
         Map<String, Object> ressourcesAttrs = new HashMap<>(attr);
 
-        if (attr.containsKey("inlineResource")){
+        if (attr.containsKey("inlineResource")) {
             ressourcesAttrs.put("body", attr.get("inlineResource").toString());
         }
         return renderTag(new AddResourcesTag(), ressourcesAttrs, renderContext);
@@ -278,61 +281,105 @@ public class RenderHelper {
     /**
      * Add a cache dependency to the current resource. This will be used to flush the current resource when the
      * dependencies are modified.
-     * @param attr may be the following:
-     *             <ul>
-     *             <li> node (JCRNodeWrapper) : The node to add as a dependency. </li>
-     *             <li> uuid (String) : The UUID of the node to add as a dependency. </li>
-     *             <li> path (String) : The path of the node to add as a dependency. </li>
-     *             <li> flushOnPathMatchingRegexp (String) : A regular expression that will be used to flush the cache
-     *             when the path of the modified nodes matches the regular expression. </li>
-     *             </ul>
+     *
+     * @param attr          may be the following:
+     *                      <ul>
+     *                      <li> node (JCRNodeWrapper) : The node to add as a dependency. </li>
+     *                      <li> uuid (String) : The UUID of the node to add as a dependency. </li>
+     *                      <li> path (String) : The path of the node to add as a dependency. </li>
+     *                      <li> flushOnPathMatchingRegexp (String) : A regular expression that will be used to flush the cache
+     *                      when the path of the modified nodes matches the regular expression. </li>
+     *                      </ul>
      * @param renderContext the current rendering context
-     * @throws IllegalAccessException if the underlying tag cannot be accessed
+     * @throws IllegalAccessException    if the underlying tag cannot be accessed
      * @throws InvocationTargetException if the underlying tag cannot be invoked
-     * @throws JspException if the underlying tag throws a JSP exception
-     * @throws IOException if the underlying tag throws an IO exception
+     * @throws JspException              if the underlying tag throws a JSP exception
+     * @throws IOException               if the underlying tag throws an IO exception
      */
     public void addCacheDependency(Map<String, Object> attr, RenderContext renderContext) throws IllegalAccessException, InvocationTargetException, JspException, IOException {
         renderTag(new AddCacheDependencyTag(), attr, renderContext);
     }
 
+    /**
+     * Calculate the relative path from one node to another node.
+     *
+     * @param currentPath the path of the current node from which to calculate the relative path
+     * @param basePath    the path of the base node to which to calculate the relative path
+     * @return the relative path from <code>currentPath</code> to <code>basePath</code>
+     */
+    static String calculateRelativePath(String currentPath, String basePath) {
+        // special case when the parent is the current node
+        if (currentPath.equals(basePath)) {
+            return ".";
+        }
+        String[] currentPathParts = currentPath.split("/");
+        String[] parentPathParts = basePath.split("/");
+
+        // Find the common prefix length
+        int commonLength = 0;
+        while (commonLength < currentPathParts.length && commonLength < parentPathParts.length
+                && currentPathParts[commonLength].equals(parentPathParts[commonLength])) {
+            commonLength++;
+        }
+
+        // Calculate the number of steps to go up from the current node to the common prefix
+        int stepsUp = currentPathParts.length - commonLength;
+
+        // Build the relative path
+        StringBuilder relativePath = new StringBuilder();
+        for (int i = 0; i < stepsUp; i++) {
+            relativePath.append("../");
+        }
+        for (int i = commonLength; i < parentPathParts.length; i++) {
+            relativePath.append(parentPathParts[i]);
+            if (i < parentPathParts.length - 1) {
+                relativePath.append("/");
+            }
+        }
+
+        return relativePath.toString();
+    }
+
+    private static <T> T readMandatoryAttribute(Map<String, Object> attr, String attributeName) {
+        T name = (T) attr.remove(attributeName);
+        if (name == null) {
+            throw new IllegalStateException(String.format("Attribute '%s' is required", attributeName));
+        }
+        return name;
+    }
+
     public String renderAbsoluteArea(Map<String, Object> attr, RenderContext renderContext) throws JspException, InvocationTargetException, IllegalAccessException, IOException {
         checkAttributes(attr, ABSOLUTEAREA_ALLOWED_ATTRIBUTES);
+        // path handling
+        String name = readMandatoryAttribute(attr, "name");
+        JCRNodeWrapper parent = readMandatoryAttribute(attr, "parent");
+        String relativePath = calculateRelativePath(renderContext.getSite().getPath(), parent.getPath());
+        attr.put("path", relativePath + "/" + name);
         return internalRenderArea(attr, "absoluteArea", renderContext);
     }
 
     public String renderArea(Map<String, Object> attr, RenderContext renderContext) throws IllegalAccessException, InvocationTargetException, JspException, IOException {
         checkAttributes(attr, AREA_ALLOWED_ATTRIBUTES);
+        String name = readMandatoryAttribute(attr, "name");
+        attr.put("path", renderContext.getMainResource().getNode().getPath() + "/" + name);
         return internalRenderArea(attr, "area", renderContext);
     }
 
     private String internalRenderArea(Map<String, Object> attr, String moduleType, RenderContext renderContext) throws IllegalAccessException, InvocationTargetException, JspException, IOException {
         // We copy the attributes to avoid modifying the original map
-        Map<String,Object> areaAttr = new HashMap<>(attr);
+        Map<String, Object> areaAttr = new HashMap<>(attr);
         areaAttr.put("moduleType", moduleType);
         // We now have to transform the attr properties into something that the AreaTag can understand
-        if (areaAttr.get("path") != null && areaAttr.get("name") != null) {
-            logger.warn("Both path and name are set on the area [ " + areaAttr.get("name") + "] tag, name will be ignored");
-            areaAttr.remove("name");
-        } else {
-            if (areaAttr.get("name") != null) {
-                areaAttr.put("path", areaAttr.get("name"));
-                areaAttr.remove("name");
-            }
-        }
-        if (areaAttr.get("areaView") != null) {
-            areaAttr.put("view", areaAttr.get("areaView"));
-            areaAttr.remove("areaView");
-        }
-        Object allowedTypes = areaAttr.get("allowedTypes");
+        Object allowedTypes = areaAttr.get("allowedNodeTypes");
         if (allowedTypes != null) {
             if (allowedTypes instanceof List) {
                 areaAttr.put("nodeTypes", StringUtils.join((List) allowedTypes, ' '));
-                areaAttr.remove("allowedTypes");
-            } if (allowedTypes.getClass().isArray()) {
+                areaAttr.remove("allowedNodeTypes");
+            }
+            if (allowedTypes.getClass().isArray()) {
                 Object[] allowedTypeArray = (Object[]) allowedTypes;
                 areaAttr.put("nodeTypes", StringUtils.join(allowedTypeArray, ' '));
-                areaAttr.remove("allowedTypes");
+                areaAttr.remove("allowedNodeTypes");
             }
         }
 
@@ -340,21 +387,16 @@ public class RenderHelper {
             areaAttr.put("listLimit", areaAttr.get("numberOfItems"));
             areaAttr.remove("numberOfItems");
         }
-
-        AreaTag areaTag = new AreaTag();
-        // The subNodesView is an attribute that is passed as a tag parameter
-        if (areaAttr.get("subNodesView") != null) {
-            areaTag.addParameter("subNodesView", (String) areaAttr.get("subNodesView"));
-            areaAttr.remove("subNodesView");
-        }
+        areaAttr.put("areaType", areaAttr.remove("nodeType"));
+        areaAttr.put("level", -1); // force the "path" parameter to be computed against the root node of the site (ex: /sites/<my-site>)
 
         // Now we remove any null attribute to make sure they don't override default tag attributes
         areaAttr = cleanupNullValues(areaAttr);
 
-        return renderTag(areaTag, areaAttr, renderContext);
+        return renderTag(new AreaTag(), areaAttr, renderContext);
     }
 
-    private Map<String,Object> cleanupNullValues(Map<String,Object> mapToClean) {
+    private Map<String, Object> cleanupNullValues(Map<String, Object> mapToClean) {
         return mapToClean.entrySet().stream()
                 .filter(entry -> entry.getValue() != null)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -372,8 +414,8 @@ public class RenderHelper {
         }
 
         String body = null;
-        if (tag instanceof BodyTagSupport &&  attr.get("body") != null) {
-           body = (String) attr.get("body");
+        if (tag instanceof BodyTagSupport && attr.get("body") != null) {
+            body = (String) attr.get("body");
         }
 
         safePopulate(tag, attr);
@@ -420,7 +462,7 @@ public class RenderHelper {
         for (Map.Entry<String, Object> entry : attr.entrySet()) {
             try {
                 BeanUtils.setProperty(tag, entry.getKey(), entry.getValue());
-            } catch (Throwable  e) {
+            } catch (Throwable e) {
                 // Ignore any errors
             }
         }
@@ -444,7 +486,7 @@ public class RenderHelper {
         this.renderService = renderService;
     }
 
-    private void checkAttributes(Map<String,Object> attributes, Set<String> allowedAttributes) {
+    private void checkAttributes(Map<String, Object> attributes, Set<String> allowedAttributes) {
         for (String attr : attributes.keySet()) {
             if (!allowedAttributes.contains(attr)) {
                 throw new IllegalArgumentException("Attribute " + attr + " is not allowed");

--- a/javascript-modules-engine-java/src/test/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelperTest.java
+++ b/javascript-modules-engine-java/src/test/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelperTest.java
@@ -1,0 +1,31 @@
+package org.jahia.modules.javascript.modules.engine.js.server;
+
+import junit.framework.TestCase;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class RenderHelperTest extends TestCase {
+
+    @Test
+    @Parameters({
+            // siblings:
+            "/home, /about, ../about",
+            "/sites/mysite/home, /sites/mysite/about, ../about",
+            // identical:
+            "/home, /home, .",
+            // parents:
+            "/home/sub-level-1, /home, ../",
+            "/home/sub-level-1/sub-level-2, /home, ../../",
+            "/home/sub-level-1/sub-level-2, /home/sub-level-1, ../",
+            // children:
+            "/home, /home/sub-level-1, sub-level-1",
+            "/home, /home/sub-level-1, sub-level-1",
+            "/home, /home/sub-level-1/sub-level-2, sub-level-1/sub-level-2"
+    })
+    public void testCalculateRelativePath(String currentPath, String basePath, String expectedRelativePath) {
+        assertEquals(expectedRelativePath, RenderHelper.calculateRelativePath(currentPath, basePath));
+    }
+}

--- a/javascript-modules-engine/tests/cypress.config.ts
+++ b/javascript-modules-engine/tests/cypress.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
     chromeWebSecurity: false,
     failOnStatusCode: false,
+    watchForFileChanges: false,
     defaultCommandTimeout: 30000,
     videoUploadOnPasses: false,
     reporter: 'cypress-multi-reporters',

--- a/javascript-modules-engine/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
+++ b/javascript-modules-engine/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
@@ -52,13 +52,21 @@ describe('Absolute Area test', () => {
                 name: 'pagecontent',
                 primaryNodeType: 'jnt:contentList',
             },
-        ]).then(() => {
-            addNode({
-                parentPathOrId: `/sites/javascriptTestSite/home/${pageName}/pagecontent`,
-                name: 'test',
-                primaryNodeType: 'javascriptExample:testAbsoluteAreas',
-            })
+        ])
+        addNode({
+            parentPathOrId: `/sites/javascriptTestSite/home/${pageName}/pagecontent`,
+            name: 'test',
+            primaryNodeType: 'javascriptExample:testAbsoluteAreas',
         })
+        addNode({
+            parentPathOrId: `/sites/javascriptTestSite/home/${pageName}/pagecontent/test`,
+            // the content node is expected to exist in TestAbsolutArea
+            name: 'basicArea',
+            primaryNodeType: 'jnt:contentList',
+        })
+        addSimplePage('/sites/javascriptTestSite', 'custom', 'Custom', 'en', 'simple').then(() =>
+            addSimplePage('/sites/javascriptTestSite/custom', 'sub-level', 'Sub level', 'en', 'simple'),
+        )
     })
 
     it(`${pageName}: Basic Area test`, () => {
@@ -117,35 +125,20 @@ describe('Absolute Area test', () => {
         cy.logout()
     })
 
-    it(`${pageName}: subNodesView Area`, () => {
+    it(`${pageName}: absolute Area home page`, () => {
         cy.login()
         cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
-        addNode({
-            parentPathOrId: `/sites/javascriptTestSite/home/${pageName}/subNodesViewArea`,
-            name: 'item1',
-            primaryNodeType: 'jnt:bigText',
-        })
-        cy.reload()
         cy.iframe('#page-builder-frame-1').within(() => {
-            cy.get('div[data-testid="subNodesViewArea"]').find('a').contains('item1')
+            cy.get('div[data-testid="absoluteAreaHomePage"] div[data-testid="row-twoColumns"]').should('exist')
         })
         cy.logout()
     })
 
-    it(`${pageName}: path Area`, () => {
+    it(`${pageName}: absolute Area custom page (sub-level)`, () => {
         cy.login()
         cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
         cy.iframe('#page-builder-frame-1').within(() => {
-            cy.get('div[data-testid="pathArea"]').find('div[type="absoluteArea"]').should('exist')
-        })
-        cy.logout()
-    })
-
-    it(`${pageName}: absolute Area`, () => {
-        cy.login()
-        cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
-        cy.iframe('#page-builder-frame-1').within(() => {
-            cy.get('div[data-testid="absoluteArea"]').find('div[data-testid="row-twoColumns"]').should('exist')
+            cy.get('div[data-testid="absoluteAreaCustomPage"]').find('div[type="absoluteArea"]').should('be.visible')
         })
         cy.logout()
     })
@@ -155,15 +148,6 @@ describe('Absolute Area test', () => {
         cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
         cy.iframe('#page-builder-frame-1').within(() => {
             cy.get('div[data-testid="nonEditableArea"]').should('be.empty')
-        })
-        cy.logout()
-    })
-
-    it(`${pageName}: absolute Area level`, () => {
-        cy.login()
-        cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
-        cy.iframe('#page-builder-frame-1').within(() => {
-            cy.get('div[data-testid="absoluteAreaLevel"]').find('div[data-testid="row-twoColumns"]').should('exist')
         })
         cy.logout()
     })

--- a/javascript-modules-engine/tests/cypress/e2e/ui/areaTest.cy.ts
+++ b/javascript-modules-engine/tests/cypress/e2e/ui/areaTest.cy.ts
@@ -78,26 +78,11 @@ describe('Area test', () => {
         cy.logout()
     })
 
-    it(`${pageName}: subNodesView Area`, () => {
-        cy.login()
-        cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
-        addNode({
-            parentPathOrId: `/sites/javascriptTestSite/home/${pageName}/subNodesViewArea`,
-            name: 'item1',
-            primaryNodeType: 'jnt:bigText',
-        })
-        cy.reload()
-        cy.iframe('#page-builder-frame-1').within(() => {
-            cy.get('div[data-testid="subNodesViewArea"]').find('a').contains('item1')
-        })
-        cy.logout()
-    })
-
     it(`${pageName}: path Area`, () => {
         cy.login()
         cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
         cy.iframe('#page-builder-frame-1').within(() => {
-            cy.get('div[data-testid="pathArea"]').find('div[type="area"]').should('exist')
+            cy.get('div[data-testid="parentArea"]').find('div[type="area"]').should('exist')
         })
         cy.logout()
     })
@@ -107,18 +92,6 @@ describe('Area test', () => {
         cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
         cy.iframe('#page-builder-frame-1').within(() => {
             cy.get('div[data-testid="nonEditableArea"]').should('be.empty')
-        })
-        cy.logout()
-    })
-
-    it(`${pageName}: Area as sub node`, () => {
-        cy.login()
-        cy.visit(`/jahia/jcontent/javascriptTestSite/en/pages/home/${pageName}`)
-        cy.iframe('#page-builder-frame-1').within(() => {
-            cy.get('div[data-testid="areaAsSubNode"]')
-                .find('div[type="area"]')
-                .should('have.attr', 'path')
-                .and('match', /\/pagecontent\/test\/areaAsSubNode$/)
         })
         cy.logout()
     })

--- a/javascript-modules-library/README.md
+++ b/javascript-modules-library/README.md
@@ -56,10 +56,10 @@ This component renders all children of the current node. It's a thin wrapper aro
 
 ### `AbsoluteArea`
 
-This component creates an absolute area in the page. It's an area of user-contributable content that is synchronized between all pages where it is present.
+This component creates an absolute area in the page. It's an area of user-contributable content, child of the a node of your choice.
 
 ```tsx
-<AbsoluteArea name="footer" />
+<AbsoluteArea name="footer" parent={renderContext.getSite().getHome()} />
 ```
 
 ### `Area`

--- a/javascript-modules-library/README.md
+++ b/javascript-modules-library/README.md
@@ -56,7 +56,7 @@ This component renders all children of the current node. It's a thin wrapper aro
 
 ### `AbsoluteArea`
 
-This component creates an absolute area in the page. It's an area of user-contributable content, child of the a node of your choice.
+This component creates an absolute area in the page. It's an area of user-contributable content, child of the node of your choice.
 
 ```tsx
 <AbsoluteArea name="footer" parent={renderContext.getSite().getHome()} />

--- a/javascript-modules-library/src/core/server/components/AbsoluteArea.tsx
+++ b/javascript-modules-library/src/core/server/components/AbsoluteArea.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useServerContext } from "../hooks/useServerContext.js";
 import server from "virtual:jahia-server";
+import type { JCRNodeWrapper } from "org.jahia.services.content";
 
 /**
  * Generates an absolute area in which editors may insert content objects.
@@ -9,28 +10,41 @@ import server from "virtual:jahia-server";
  */
 export function AbsoluteArea({
   name,
+  parent,
   areaView,
+  view,
   allowedTypes,
+  allowedNodeTypes,
   numberOfItems,
-  subNodesView,
-  path,
   readOnly = false,
-  level,
   areaType = "jnt:contentList",
+  nodeType = "jnt:contentList",
   parameters,
 }: Readonly<{
   /** The name of the area. */
-  name?: string;
-  /** The view to use for the area. */
+  name: string;
+  /** Parent node where the area is stored in the JCR. The parent node must exist. */
+  parent: JCRNodeWrapper;
+
+  /**
+   * The view to use for the area.
+   *
+   * @deprecated Use {@link #view} instead
+   */
   areaView?: string;
-  /** The allowed types for the area. */
+  /** The view to use for the area. */
+  view?: string;
+  /**
+   * The allowed types for the area.
+   *
+   * @deprecated Use {@link #allowedNodeTypes} instead
+   */
   allowedTypes?: string[];
+  /** The allowed types for the area. */
+  allowedNodeTypes?: string[];
   /** The number of items to display in the area. */
   numberOfItems?: number;
-  /** The view to use for the subnodes. */
-  subNodesView?: string;
-  /** Relative (to the current node) or absolute path to the node to include. */
-  path?: string;
+
   /**
    * Makes the area read-only.
    *
@@ -42,15 +56,24 @@ export function AbsoluteArea({
    * @default false
    */
   readOnly?: boolean | "children";
-  /** Ancestor level for absolute area - 0 is Home page, 1 first sub-pages, ... */
-  level?: number;
   /**
-   * Content type to be used to create the area
+   * Content node type to be used to create the area (if the node does not exist yet)
    *
+   * @deprecated Use {@link #nodeType} instead
    * @default jnt:contentList
    */
   areaType?: string;
-  /** The parameters to pass to the absolute area */
+  /**
+   * Content node type to be used to create the area (if the node does not exist yet)
+   *
+   * @default jnt:contentList
+   */
+  nodeType?: string;
+  /**
+   * Map of custom parameters that can be passed to the backend engine for advanced logic.
+   *
+   * @deprecated Not recommended
+   */
   parameters?: Record<string, unknown>;
 }>): React.JSX.Element {
   const { renderContext } = useServerContext();
@@ -61,14 +84,12 @@ export function AbsoluteArea({
         __html: server.render.renderAbsoluteArea(
           {
             name,
-            areaView,
-            allowedTypes,
+            parent: parent,
+            view: view ? view : areaView,
+            allowedNodeTypes: allowedNodeTypes ?? allowedTypes,
             numberOfItems,
-            subNodesView,
-            path,
+            nodeType: nodeType ?? areaType,
             editable: readOnly !== true,
-            level,
-            areaType,
             limitedAbsoluteAreaEdit: readOnly === "children",
             parameters,
           },

--- a/javascript-modules-library/src/core/server/components/Area.tsx
+++ b/javascript-modules-library/src/core/server/components/Area.tsx
@@ -10,46 +10,62 @@ import server from "virtual:jahia-server";
 export function Area({
   name,
   areaView,
+  view,
   allowedTypes,
+  allowedNodeTypes,
   numberOfItems,
-  subNodesView,
-  path,
   readOnly = false,
-  areaAsSubNode,
   areaType = "jnt:contentList",
+  nodeType = "jnt:contentList",
   parameters,
 }: Readonly<{
   /** The name of the area. */
-  name?: string;
-  /** The view to use for the area. */
+  name: string;
+
+  /**
+   * The view to use for the area.
+   *
+   * @deprecated Use {@link #view} instead
+   */
   areaView?: string;
-  /** The allowed types for the area. */
+  /** The view to use for the area. */
+  view?: string;
+  /**
+   * The allowed types for the area.
+   *
+   * @deprecated Use {@link #allowedNodeTypes} instead
+   */
   allowedTypes?: string[];
+  /** The allowed types for the area. */
+  allowedNodeTypes?: string[];
   /** The number of items to display in the area. */
   numberOfItems?: number;
-  /** The view to use for the subnodes. */
-  subNodesView?: string;
-  /** Relative (to the current node) or absolute path to the node to include. */
-  path?: string;
+
   /**
    * Makes the area read-only.
    *
    * @default false
    */
   readOnly?: boolean;
+
   /**
-   * Allow area to be stored as a subnode
+   * Content node type to be used to create the area (if the node does not exist yet)
    *
-   * @deprecated Use child node(s) and `<RenderChild(ren) />` instead
-   */
-  areaAsSubNode?: boolean;
-  /**
-   * Content type to be used to create the area
-   *
+   * @deprecated Use {@link #nodeType} instead
    * @default jnt:contentList
    */
   areaType?: string;
-  /** The parameters to pass to the area */
+  /**
+   * Content node type to be used to create the area (if the node does not exist yet)
+   *
+   * @default jnt:contentList
+   */
+  nodeType?: string;
+  /**
+   * Map of custom parameters that can be passed to the backend engine for advanced logic.
+   *
+   * @deprecated Not recommended
+   */
   parameters?: Record<string, unknown>;
 }>): JSX.Element {
   const { renderContext } = useServerContext();
@@ -60,14 +76,11 @@ export function Area({
         __html: server.render.renderArea(
           {
             name,
-            areaView,
-            allowedTypes,
+            view: view ?? areaView,
+            allowedNodeTypes: allowedNodeTypes ?? allowedTypes,
             numberOfItems,
-            subNodesView,
-            path,
+            nodeType: nodeType ?? areaType,
             editable: !readOnly,
-            areaAsSubNode,
-            areaType,
             parameters,
           },
           renderContext,


### PR DESCRIPTION
### Description
Addresses https://github.com/Jahia/javascript-modules/issues/179.
Refactor and simplify `<Area>` and `<AbsoluteArea>` components (with **breaking changes**!).

### Usages
To use a fixed JCR node content of a given page:
```
<AbsoluteArea name="yourContentNode" parent={yourPageNode}>
```
This would store (and create if it does not exist) the content node `yourContentNode` (of type `"jnt:contentList"`) as a child node of `yourPageNode` (a `JCRNodeWrapper`).
For instance, to use the `main` node of the home page:
```
<AbsoluteArea name="main" parent={renderContext.getSite().getHome()} />
```
Or to use a different page (at a custom hierarchy):
```
<AbsoluteArea name="main" parent={renderContext.getSite().getNode("your-page/your-sub-page")} />
```

A content node relative to the current page can also be used:
```
<AbsoluteArea name="main" parent={currentNode} />
```
Which is equivalent to use a classic `<Area>`:
```
<Area name="main" />
```
