### PR TITLE
docs: Use latest version for init module

### DIFF
--- a/docs/1-getting-started/1-dev-environment/README.md
+++ b/docs/1-getting-started/1-dev-environment/README.md
@@ -44,7 +44,7 @@ You can start this part while Jahia is downloading. We'll create a new project u
 
 ```bash
 # Create a new project in ./hydrogen
-npm init @jahia/module hydrogen
+npm init @jahia/module@latest hydrogen
 ```
 
 Once your project is ready, the tool will suggest you to run a few commands to start it. You can run them all except the last one, `yarn build && yarn dev`, because Jahia is not ready yet. Please note that git commands, while optional, are strongly recommended. If `code .` doesn't work, open your code editor and open the project folder manually.

--- a/javascript-create-module/README.md
+++ b/javascript-create-module/README.md
@@ -7,7 +7,7 @@ This CLI scaffolds a new Jahia JavaScript module.
 To create a new module, run:
 
 ```
-npm init @jahia/module <module-name>
+npm init @jahia/module@latest <module-name>
 ```
 
 It creates a new JavaScript Module in a directory named `module-name` in the current working directory.

--- a/javascript-create-module/index.js
+++ b/javascript-create-module/index.js
@@ -26,7 +26,7 @@ Upgrade guide: ${styleText("underline", "https://nodejs.org/en/download")}
     console.error(
       `No module name provided.
 
-  Usage: npm init @jahia/module ${styleText("blueBright", "<module-name>")}
+  Usage: npm init @jahia/module@latest ${styleText("blueBright", "<module-name>")}
 
 It will create a new module at this location with the provided name:
 


### PR DESCRIPTION
### Description
Addresses https://github.com/Jahia/javascript-modules/issues/242.

Specify to use `@latest` when running the `npm init` command to ensure the latest version is used, in case the package already exists globally.
As per the [npm-init documentation](https://docs.npmjs.com/cli/v8/commands/npm-init):
> Note: if a user already has the create-<initializer> package globally installed, that will be what npm init uses. If you want npm to use the latest version, or another specific version you must specify it

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
