### PR TITLE
fix: Fix URLs to import the prepackaged site

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -62,4 +62,4 @@ jobs:
     env:
       # During manual tests, the prepackaged site is fetched from a Maven repository.
       # For test executions using built artifacts, a local prepackaged archive is used (moved to the ./artifacts/ folder during the build).
-      CYPRESS_PREPACKAGED_SITE_URL: "jar:mvn:org.jahia.samples/javascript-modules-samples-hydrogen-prepackaged/zip!/site.zip"
+      CYPRESS_PREPACKAGED_SITE_URL: "jar:mvn:org.jahia.samples/javascript-modules-samples-hydrogen-prepackaged/LATEST/zip!/site.zip"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,4 +61,4 @@ jobs:
     env:
       # During nightly tests, the prepackaged site is fetched from a Maven repository.
       # For test executions using built artifacts, a local prepackaged archive is used (moved to the ./artifacts/ folder during the build).
-      CYPRESS_PREPACKAGED_SITE_URL: "jar:mvn:org.jahia.samples/javascript-modules-samples-hydrogen-prepackaged/zip!/site.zip"
+      CYPRESS_PREPACKAGED_SITE_URL: "jar:mvn:org.jahia.samples/javascript-modules-samples-hydrogen-prepackaged/LATEST/zip!/site.zip"

--- a/samples/README.md
+++ b/samples/README.md
@@ -40,5 +40,5 @@ yarn dev
 7. Install the pre-packaged site:
 
 ```
-curl -u "root:root1234" -X POST http://localhost:8080/modules/api/provisioning --form script='[{"importSite":"jar:mvn:org.jahia.samples/javascript-modules-samples-hydrogen-prepackaged/zip!/site.zip"}]' 
+curl -u "root:root1234" -X POST http://localhost:8080/modules/api/provisioning --form script='[{"importSite":"jar:mvn:org.jahia.samples/javascript-modules-samples-hydrogen-prepackaged/LATEST/zip!/site.zip"}]' 
 ```


### PR DESCRIPTION
### Description
Fix the URLs used in provisioning files to import the prepackaged site (the version must be specified - `LATEST` simply takes the latest available on Nexus).
This should fix the [nightly tests](https://github.com/Jahia/javascript-modules/actions/runs/14232158874).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
