### PR TITLE
fix: updated jahia parent to 8.2.1.0 and rolled back codebase version to 0.6.1

### DIFF
--- a/jahia-test-module/pom.xml
+++ b/jahia-test-module/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javascript-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <groupId>org.jahia.test</groupId>
     <artifactId>javascript-modules-engine-test-module</artifactId>

--- a/javascript-create-module/package.json
+++ b/javascript-create-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/create-module",
-  "version": "0.7.0-SNAPSHOT",
+  "version": "0.6.1-SNAPSHOT",
   "keywords": [
     "template"
   ],

--- a/javascript-create-module/pom.xml
+++ b/javascript-create-module/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javascript-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <artifactId>javascript-create-module</artifactId>
     <name>Javascript create module</name>

--- a/javascript-modules-engine-java/pom.xml
+++ b/javascript-modules-engine-java/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>javascript-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <artifactId>javascript-modules-engine-java</artifactId>
     <name>Javascript Modules Engine Java</name>

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jshandler/JavascriptProtocolConnection.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jshandler/JavascriptProtocolConnection.java
@@ -209,7 +209,7 @@ public class JavascriptProtocolConnection extends URLConnection {
         setIfPresent(jahiaProps, "module-priority", instructions, "Jahia-Module-Priority");
         instructions.put("Jahia-Module-Type", jahiaProps.getOrDefault("module-type", "module"));
         setIfPresent(jahiaProps, "private-app-store", instructions, "Jahia-Private-App-Store");
-        instructions.put("Jahia-Required-Version", jahiaProps.getOrDefault("required-version", "8.2.0.0"));
+        instructions.put("Jahia-Required-Version", jahiaProps.getOrDefault("required-version", "8.2.1.0"));
         setIfPresent(jahiaProps, "server", instructions, BUNDLE_HEADER_JAVASCRIPT_INIT_SCRIPT);
         // always include "/static" as folder for the static resources
         instructions.put("Jahia-Static-Resources", StringUtils.defaultIfEmpty((String) jahiaProps.get("static-resources"), "/css,/icons,/images,/img,/javascript") + ",/static");

--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>javascript-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <artifactId>javascript-modules-engine</artifactId>
     <name>Javascript Modules Engine</name>
@@ -29,7 +29,7 @@
     <description>This is the engine allowing Javascript modules to run on a Jahia server.</description>
 
     <properties>
-        <jahia-module-signature>MC0CFFNmSp3nFJsnMdpW0xRVEvQ9fzxBAhUAhbGeMDieoSF6Q2ZknB8tjhBSSvI=</jahia-module-signature>
+        <jahia-module-signature>MCwCFCKnpC2WF0H7/LeX30dn92RKKYi7AhR6trSU/HD1TXIvxex1HbYofSfAOA==</jahia-module-signature>
         <import-package>
             graphql.annotations.annotationTypes;version="[7.2,99)",
             graphql.schema;version="[13.0,22)",

--- a/javascript-modules-engine/tests/provisioning-manifest-snapshot.yml
+++ b/javascript-modules-engine/tests/provisioning-manifest-snapshot.yml
@@ -5,11 +5,11 @@
   uninstallPreviousVersion: true
 
 - installBundle:
-      - 'js:mvn:org.jahia.test/javascript-modules-engine-test-module/0.7.0-SNAPSHOT/tgz'
+      - 'js:mvn:org.jahia.test/javascript-modules-engine-test-module/0.6.1-SNAPSHOT/tgz'
   autoStart: true
   uninstallPreviousVersion: true
 
 - installBundle:
-    - 'js:mvn:org.jahia.samples/javascript-modules-samples-hydrogen/0.7.0-SNAPSHOT/tgz'
+      - 'js:mvn:org.jahia.samples/javascript-modules-samples-hydrogen/0.6.1-SNAPSHOT/tgz'
   autoStart: true
   uninstallPreviousVersion: true

--- a/javascript-modules-library/package.json
+++ b/javascript-modules-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/javascript-modules-library",
-  "version": "0.7.0-SNAPSHOT",
+  "version": "0.6.1-SNAPSHOT",
   "homepage": "https://github.com/Jahia/javascript-modules/tree/main/javascript-modules-library#readme",
   "bugs": {
     "url": "https://github.com/Jahia/javascript-modules/issues"

--- a/javascript-modules-library/pom.xml
+++ b/javascript-modules-library/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javascript-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <artifactId>javascript-modules-library</artifactId>
     <name>Javascript Modules Library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0</version>
+        <version>8.2.1.0</version>
     </parent>
     <artifactId>javascript-modules</artifactId>
     <name>Javascript Modules</name>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.6.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Multi-module project with the backend engine and the frontend library allowing Javascript modules to
         run on a Jahia server.

--- a/samples/hydrogen-prepackaged/pom.xml
+++ b/samples/hydrogen-prepackaged/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>javascript-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.samples</groupId>

--- a/samples/hydrogen/package.json
+++ b/samples/hydrogen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydrogen",
-  "version": "0.7.0-SNAPSHOT",
+  "version": "0.6.1-SNAPSHOT",
   "type": "module",
   "files": [
     "dist",

--- a/samples/hydrogen/pom.xml
+++ b/samples/hydrogen/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javascript-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.samples</groupId>

--- a/vite-plugin/package.json
+++ b/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/vite-plugin",
-  "version": "0.7.0-SNAPSHOT",
+  "version": "0.6.1-SNAPSHOT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com:Jahia/javascript-modules.git",

--- a/vite-plugin/pom.xml
+++ b/vite-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>javascript-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.6.1-SNAPSHOT</version>
     </parent>
     <artifactId>vite-plugin</artifactId>
     <name>Vite plugin for Jahia</name>


### PR DESCRIPTION
During testing, we discovered that javascript-modules-engine was not compatible with Jahia 8.2.0.0 anymore, it was decided to update the parent to 8.2.1.0.

Updated all versions back to 0.6.1-SN