### PR TITLE
build: Use an 'alpha' tag when building on merge to main

### DIFF
--- a/javascript-create-module/pom.xml
+++ b/javascript-create-module/pom.xml
@@ -27,8 +27,8 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
+                <!-- Map Yarn commands to corresponding Maven phases -->
                 <executions>
-                    <!-- Executions bound on the "initialize" phase (executed in order of declaration): -->
                     <execution>
                         <id>install node and yarn</id>
                         <phase>initialize</phase>
@@ -43,7 +43,6 @@
                             <goal>yarn</goal>
                         </goals>
                     </execution>
-                    <!-- Executions bound on the "compile" phase (executed in order of declaration): -->
                     <execution>
                         <id>yarn lint</id>
                         <phase>compile</phase>
@@ -72,6 +71,36 @@
                         </goals>
                         <configuration>
                             <arguments>test</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>set-alpha-version</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>node ../.m2/sync-version.js ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-alpha-${timestamp}</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>publish-alpha-tag</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>npm publish --tag alpha --access public</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>reset-version</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>node ../.m2/sync-version.js ${project.version}</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/javascript-modules-library/pom.xml
+++ b/javascript-modules-library/pom.xml
@@ -34,8 +34,8 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
+                <!-- Map Yarn commands to corresponding Maven phases -->
                 <executions>
-                    <!-- Executions bound on the "initialize" phase (executed in order of declaration): -->
                     <execution>
                         <id>install node and yarn</id>
                         <phase>initialize</phase>
@@ -50,7 +50,6 @@
                             <goal>yarn</goal>
                         </goals>
                     </execution>
-                    <!-- Executions bound on the "compile" phase (executed in order of declaration): -->
                     <execution>
                         <id>yarn lint</id>
                         <phase>compile</phase>
@@ -69,6 +68,36 @@
                         </goals>
                         <configuration>
                             <arguments>build</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>set-alpha-version</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>node ../.m2/sync-version.js ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-alpha-${timestamp}</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>publish-alpha-tag</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>npm publish --tag alpha --access public</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>reset-version</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>node ../.m2/sync-version.js ${project.version}</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,16 @@
                     <artifactId>cyclonedx-maven-plugin</artifactId>
                     <version>2.9.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.6.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>3.2.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -168,6 +178,39 @@
                     <completionGoals>-P release-prepare clean install scm:checkin</completionGoals>
                     <releaseProfiles>release-perform</releaseProfiles>
                     <useReleaseProfile>true</useReleaseProfile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- extract the components of the version in Maven variables:
+                            - ${parsedVersion.majorVersion}
+                            - ${parsedVersion.minorVersion}
+                            - ${parsedVersion.incrementalVersion}
+                        -->
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- create a ${timestamp} Maven variable with the build timestamp -->
+                        <goals>
+                            <goal>create-timestamp</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- use UTC to ensure the timestamps between 2 builds are in the correct SemVer order -->
+                    <timestampFormat>yyyyMMddHHmmssSSS</timestampFormat>
+                    <timezone>UTC</timezone>
                 </configuration>
             </plugin>
         </plugins>

--- a/vite-plugin/pom.xml
+++ b/vite-plugin/pom.xml
@@ -26,8 +26,8 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
+                <!-- Map Yarn commands to corresponding Maven phases -->
                 <executions>
-                    <!-- Executions bound on the "initialize" phase (executed in order of declaration): -->
                     <execution>
                         <id>install node and yarn</id>
                         <phase>initialize</phase>
@@ -50,6 +50,36 @@
                         </goals>
                         <configuration>
                             <arguments>build</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>set-alpha-version</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>node ../.m2/sync-version.js ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-alpha-${timestamp}</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>publish-alpha-tag</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>npm publish --tag alpha --access public</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>reset-version</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>node ../.m2/sync-version.js ${project.version}</arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
### Description
When executing a `mvn deploy` (done by the  _On merge to main_ Github workflow), deploy an _alpha_ version to the [NPM registry](https://www.npmjs.com/), similar to what is done with Maven snapshots.

**Important**: As a `tag` parameter is passed to the [`yarn npm publish`](https://yarnpkg.com/cli/npm/publish) command, the default _latest_ tag is overwritten, meaning the alpha version getting published will *not* be resolved by `"@jahia/javascript-modules-library": "latest"`.

The following modules have their NPM packages published:
- [@jahia/create-module](https://www.npmjs.com/package/@jahia/create-module)
- [@jahia/javascript-modules-library](https://www.npmjs.com/package/@jahia/javascript-modules-library)
- [@jahia/vite-plugin](https://www.npmjs.com/package/@jahia/vite-plugin)

The format used for the packages versions (set in the `package.json` files) is:
```
<major>.<minor>.<patch>-alpha-<timestamp>
```
So a build of the version 1.2.3-SNAPSHOT would give something like:
```
1.2.3-alpha-20250404151723685
```

*NB*: The temp alpha version has to be reset (done in the `reset-version` executions) to make sure the releases contain the correct project's version.

### Checklist

#### Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
