### PR TITLE
build(samples): Attach Hydrogen artifact to the Maven build

### DIFF
--- a/samples/hydrogen/pom.xml
+++ b/samples/hydrogen/pom.xml
@@ -69,6 +69,28 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- attach the dist/package.tgz artifact to the Maven build so it will be installed/deployed as part of the Maven build -->
+                        <!-- bound to the "package" phase -->
+                        <id>attach-tgz-artifact</id>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>dist/package.tgz</file>
+                                    <type>tgz</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
### Description

Attach Hydrogen (sample JS module) artifact (generated in `dist/package.tgz`) to the Maven lifecycle, so the `tgz` archive gets installed/deployed during the Maven build.
This should fix the issue encountered with the nighlty tests where the package can't be retrieved:
```
ERROR [InstallBundle] - Cannot install js:mvn:org.jahia.samples/javascript-modules-samples-hydrogen/0.6.1-SNAPSHOT/tgz = java.io.IOException. Please make sure the artifact is reachable within the registered maven repositories (network, credentials ...)
```


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
