### PR TITLE
build: Align versions in provisioning with release 0.7.0-SNAPSHOT

### DIFF
--- a/javascript-modules-engine/tests/provisioning-manifest-snapshot.yml
+++ b/javascript-modules-engine/tests/provisioning-manifest-snapshot.yml
@@ -5,11 +5,11 @@
   uninstallPreviousVersion: true
 
 - installBundle:
-      - 'js:mvn:org.jahia.test/javascript-modules-engine-test-module/0.6.1-SNAPSHOT/tgz'
+      - 'js:mvn:org.jahia.test/javascript-modules-engine-test-module/0.7.0-SNAPSHOT/tgz'
   autoStart: true
   uninstallPreviousVersion: true
 
 - installBundle:
-      - 'js:mvn:org.jahia.samples/javascript-modules-samples-hydrogen/0.6.1-SNAPSHOT/tgz'
+      - 'js:mvn:org.jahia.samples/javascript-modules-samples-hydrogen/0.7.0-SNAPSHOT/tgz'
   autoStart: true
   uninstallPreviousVersion: true


### PR DESCRIPTION
### Description
Following the [release of 0.6.1](https://github.com/Jahia/javascript-modules/releases/tag/0_6_1), the provisioning files (to install the test modules) must be aligned with the current development version (0.7.0-SNAPSHOT)

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
