### PR TITLE
ci: configure credentials to publish npm package

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -121,6 +121,10 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
+      - name: Setup .yarnrc.yml file to allow publication to https://registry.npmjs.org with a 'yarn npm publish'
+        shell: bash
+        run: |
+          echo "npmAuthToken: ${{ secrets.NPMJS_PUBLISH_TOKEN }}" >> ~/.yarnrc.yml
       - uses: jahia/jahia-modules-action/publish@v2
         with:
           # the test module is built as part of the Maven build


### PR DESCRIPTION
### Description
Following https://github.com/Jahia/javascript-modules/pull/254, the authentication token to allow publication to https://registry.npmjs.org has to be set in the Github workflow when merging to main.

Should fix [the error](https://github.com/Jahia/javascript-modules/actions/runs/14327789688/job/40161491037) encountered during the publication step:
```
[INFO] Running 'yarn npm publish --tag alpha --access public' in /__w/javascript-modules/javascript-modules/vite-plugin
[INFO] ➤ YN0000: README.md
[INFO] ➤ YN0000: dist/index.d.ts
[INFO] ➤ YN0000: dist/index.js
[INFO] ➤ YN0000: package.json
[INFO] ➤ YN0033: No authentication configured for request
[INFO] ➤ YN0000: Failed with errors in 0s 24ms
...
Error:  Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.15.1:yarn (publish-alpha-tag) on project vite-plugin: Failed to run task: 'yarn npm publish --tag alpha --access public' failed. org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1) -> [Help 1]
```

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
