### PR TITLE
chore: Remove duplicated plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,11 +156,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.6.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
                     <version>3.2.1</version>
                 </plugin>


### PR DESCRIPTION
### Description
Remove the duplicated declaration of `build-helper-maven-plugin` (already declared [here](https://github.com/Jahia/javascript-modules/blob/main/pom.xml#L142)) that currently generates a warning when building:
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.jahia.test:javascript-modules-engine-test-module:pom:0.7.0-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.codehaus.mojo:build-helper-maven-plugin @ org.jahia.modules:javascript-modules:0.7.0-SNAPSHOT, /Users/baptistegrimaud/Documents/code/jahia/javascript-modules/pom.xml, line 157, column 25
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.jahia.modules:javascript-modules:pom:0.7.0-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.codehaus.mojo:build-helper-maven-plugin @ line 157, column 25
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 

```


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
