### PR TITLE
build: Migrate commons-lang -> commons-lang3

### DIFF
--- a/javascript-modules-engine-java/.java-ts-bind/package.json
+++ b/javascript-modules-engine-java/.java-ts-bind/package.json
@@ -6,7 +6,7 @@
       "target/java-ts-bind/sources/dependencies"
     ],
     "symbols": [
-      "target/java-ts-bind/jars/commons-lang.jar",
+      "target/java-ts-bind/jars/commons-lang3.jar",
       "target/java-ts-bind/jars/graal-sdk.jar",
       "target/java-ts-bind/jars/jackrabbit-spi-commons.jar",
       "target/java-ts-bind/jars/jahia-impl.jar",

--- a/javascript-modules-engine-java/.java-ts-bind/package.json
+++ b/javascript-modules-engine-java/.java-ts-bind/package.json
@@ -434,7 +434,7 @@
       "javax.servlet.RequestDispatcher",
       "javax.servlet.ServletContext",
       "javax.servlet.http.HttpServlet",
-      "org.apache.commons.lang.mutable.MutableInt",
+      "org.apache.commons.lang3.mutable.MutableInt",
       "org.jahia.api.usermanager.JahiaUserManagerService",
       "org.jahia.data.beans.CategoryBean",
       "org.jahia.data.templates.JahiaTemplatesPackage",

--- a/javascript-modules-engine-java/pom.xml
+++ b/javascript-modules-engine-java/pom.xml
@@ -190,7 +190,7 @@
                         </goals>
                         <configuration>
                             <includeArtifactIds>
-                                commons-lang,
+                                commons-lang3,
                                 graal-sdk,
                                 jackrabbit-spi-commons,
                                 jahia-impl,

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelper.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelper.java
@@ -16,7 +16,7 @@
 package org.jahia.modules.javascript.modules.engine.js.server;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.util.Text;
 import org.apache.taglibs.standard.tag.common.core.ParamParent;
 import org.graalvm.polyglot.proxy.ProxyArray;

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/GraalVMEngine.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/GraalVMEngine.java
@@ -17,7 +17,7 @@ package org.jahia.modules.javascript.modules.engine.jsengine;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.pool2.BasePooledObjectFactory;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jshandler/JavascriptProtocolConnection.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jshandler/JavascriptProtocolConnection.java
@@ -18,7 +18,7 @@ package org.jahia.modules.javascript.modules.engine.jshandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.ops4j.pax.swissbox.bnd.BndUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/views/JavascriptTemplatesNodeChoiceListInitializer.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/views/JavascriptTemplatesNodeChoiceListInitializer.java
@@ -15,7 +15,7 @@
  */
 package org.jahia.modules.javascript.modules.engine.views;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jahia.bin.Jahia;
 import org.jahia.modules.javascript.modules.engine.registrars.ViewsRegistrar;
 import org.jahia.services.content.JCRNodeWrapper;


### PR DESCRIPTION
### Description
Use a single Apache Commons Lang (`commons-lang3`) library instead of 2 (`commons-lang` and `commons-lang3`).

Consequently, this removes the `org.apache.commons.lang` from the list of dependencies in the `Import-Package`.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
