### PR TITLE
build: Remove Spring from *.d.ts files

### DIFF
--- a/javascript-modules-engine-java/.java-ts-bind/package.json
+++ b/javascript-modules-engine-java/.java-ts-bind/package.json
@@ -17,9 +17,6 @@
       "target/java-ts-bind/jars/jsp-api.jar",
       "target/java-ts-bind/jars/org.apache.felix.framework.jar",
       "target/java-ts-bind/jars/osgi.annotation.jar",
-      "target/java-ts-bind/jars/spring-beans.jar",
-      "target/java-ts-bind/jars/spring-context.jar",
-      "target/java-ts-bind/jars/spring-web.jar",
       "target/java-ts-bind/jars/xml-apis.jar"
     ],
     "out": "target/java-ts-bind/types",
@@ -470,9 +467,6 @@
       "org.osgi.framework.BundleListener",
       "org.osgi.framework.FrameworkListener",
       "org.osgi.framework.ServiceListener",
-      "org.springframework.beans.factory.DisposableBean",
-      "org.springframework.beans.factory.InitializingBean",
-      "org.springframework.web.context.ServletContextAware",
       "org.xml.sax.ContentHandler"
     ],
     "gettersAndSettersOff": true,

--- a/javascript-modules-engine-java/pom.xml
+++ b/javascript-modules-engine-java/pom.xml
@@ -200,9 +200,6 @@
                                 jsp-api,
                                 org.apache.felix.framework,
                                 osgi.annotation,
-                                spring-beans,
-                                spring-context,
-                                spring-web,
                                 xml-apis
                             </includeArtifactIds>
                             <outputDirectory>${project.build.directory}/java-ts-bind/jars</outputDirectory>


### PR DESCRIPTION
### Description

Remove Spring dependencies from the generation of the TypeScript Declaration files (`*.d.ts`).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
