### PR TITLE
build: Use Jakarta Server Pages API

### DIFF
--- a/javascript-modules-engine-java/.java-ts-bind/package.json
+++ b/javascript-modules-engine-java/.java-ts-bind/package.json
@@ -10,11 +10,11 @@
       "target/java-ts-bind/jars/graal-sdk.jar",
       "target/java-ts-bind/jars/jackrabbit-spi-commons.jar",
       "target/java-ts-bind/jars/jahia-impl.jar",
+      "target/java-ts-bind/jars/jakarta.servlet.jsp-api.jar",
       "target/java-ts-bind/jars/javascript-modules-engine-java-classes.jar",
       "target/java-ts-bind/jars/javax.servlet-api.jar",
       "target/java-ts-bind/jars/jboss-servlet-api_3.1_spec.jar",
       "target/java-ts-bind/jars/jcr.jar",
-      "target/java-ts-bind/jars/jsp-api.jar",
       "target/java-ts-bind/jars/org.apache.felix.framework.jar",
       "target/java-ts-bind/jars/osgi.annotation.jar",
       "target/java-ts-bind/jars/xml-apis.jar"

--- a/javascript-modules-engine-java/pom.xml
+++ b/javascript-modules-engine-java/pom.xml
@@ -82,9 +82,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <version>2.1</version>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <version>2.3.6</version> <!-- defined in Jahia/org.ops4j.pax.web/pom.xml -->
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -194,10 +194,10 @@
                                 graal-sdk,
                                 jackrabbit-spi-commons,
                                 jahia-impl,
+                                jakarta.servlet.jsp-api,
                                 javax.servlet-api,
                                 jboss-servlet-api_3.1_spec,
                                 jcr,
-                                jsp-api,
                                 org.apache.felix.framework,
                                 osgi.annotation,
                                 xml-apis

--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -77,9 +77,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <version>2.1</version>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <version>2.3.6</version> <!-- defined in Jahia/org.ops4j.pax.web/pom.xml -->
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
### Description
Replace the deprecated [`javax.servlet.jsp:jsp-api`](https://mvnrepository.com/artifact/javax.servlet.jsp/jsp-api) by [`jakarta.servlet.jsp:jakarta.servlet.jsp-api`](https://mvnrepository.com/artifact/jakarta.servlet.jsp/jakarta.servlet.jsp-api), provided by `org.ops4j.pax.web/pax-web-features`, a [core feature](https://github.com/Jahia/jahia/blob/138184f5dfebda15f9c11c66524140c057457049/features/core/src/main/feature/feature.xml#L6).

**NB:** The generated `*.d.ts` files remain identical.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
