### PR TITLE
build: Remove GraphQL OSGI imports

### DIFF
--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -30,14 +30,6 @@
 
     <properties>
         <jahia-module-signature>MCsCFHQLKOK7O2Q/j38Puro78KPX4sqVAhM6ywV7HEhKveasQixBgigZLYyO</jahia-module-signature>
-        <import-package>
-            graphql.annotations.annotationTypes;version="[7.2,99)",
-            graphql.schema;version="[13.0,22)",
-            org.jahia.modules.graphql.provider.dxm;version="[2.7,4)",
-            org.jahia.modules.graphql.provider.dxm.node;version="[2.7,4)",
-            org.jahia.modules.graphql.provider.dxm.osgi.annotations;version="[2.7,4)",
-            org.jahia.modules.graphql.provider.dxm.util;version="[2.7,4)",
-        </import-package>
         <require-capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version&gt;=17))"</require-capability>
         <yarn-build>build</yarn-build>
     </properties>


### PR DESCRIPTION
### Description
Remove the imports of [graphql-dxm-provider's APIs](https://github.com/Jahia/graphql-core/tree/master/graphql-dxm-provider) as they are not used by the _JavaScript Modules Engine_.

Follows https://github.com/Jahia/javascript-modules/pull/287.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
