### PR TITLE
fix: allows relative areas to make template inheritance working, as system like jExperience page perso/opti are using it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .idea
 *.iml
+.env
 
 # Maven
 target/

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelper.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelper.java
@@ -360,8 +360,11 @@ public class RenderHelper {
 
     public String renderArea(Map<String, Object> attr, RenderContext renderContext) throws IllegalAccessException, InvocationTargetException, JspException, IOException {
         checkAttributes(attr, AREA_ALLOWED_ATTRIBUTES);
-        String name = readMandatoryAttribute(attr, "name");
-        attr.put("path", renderContext.getMainResource().getNode().getPath() + "/" + name);
+        // This is actually expected, the path of an area is relative by default, so the name is directly mapped to: path
+        // the AreaTag will resolve the area content using template inheritance hierarchy.
+        // Even if it's not used in the javascript engine, we need to respect this concept for compatibility with existing system relying on this behavior.
+        // (jExperience for example is using this behavior, for page perso/opti, by pushing the page variant node as parent template)
+        attr.put("path", readMandatoryAttribute(attr, "name"));
         return internalRenderArea(attr, "area", renderContext);
     }
 


### PR DESCRIPTION
### Description

Goal is to allows area to be relative, in orde for jahia rendering template hierachy to works properly.
This system is for now used by jExperience page perso/opti to push page variant as template node.
(in other words this changes, is making jExperience page perso/opti current implementation working properly with JavaScript pages)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
