### PR TITLE
build: Disable concurrency for 'on merge' workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -11,6 +11,11 @@ on:
     tags-ignore:
       - "**"
 
+concurrency:
+  # ensure there is at most one execution of this workflow at any time
+  # if another workflow is "in progress", the queued workflow will be "pending"
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+
 jobs:
   update-signature:
     name: Update module signature


### PR DESCRIPTION
### Description
Should fix the error:
```
[INFO] ➤ YN0035: Failed to save packument. A common cause is if you try to publish a new package before the previous package has been fully processed.
[INFO] ➤ YN0035:   Response Code: 409 (Conflict)
[INFO] ➤ YN0035:   Request Method: PUT
[INFO] ➤ YN0035:   Request URL: https://registry.yarnpkg.com/@jahia%2fjavascript-modules-library
[INFO] ➤ YN0000: Failed with errors in 1s 613ms
```
encountered when multiple "on merge" workflows are executed in parallel ([example here](https://github.com/Jahia/javascript-modules/actions/runs/14833988262/job/41642616520))

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
