### PR TITLE
chore: less noisy renovate prs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
     "dependencyDashboardApproval": true
   },
   "patch": {
-    "automerge": true
+    "automerge": true,
+    "groupName": "patch"
   }
 }


### PR DESCRIPTION
### Description

By setting the same `groupName` to all patch PRs, I expect renovate to create a single PR for all patches

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
