### PR TITLE
fix: templates/ not packaged in create-module

### DIFF
--- a/javascript-create-module/package.json
+++ b/javascript-create-module/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "bin": "./index.js",
   "files": [
-    "template"
+    "templates"
   ],
   "scripts": {
     "build": "yarn pack --out dist/package.tgz && publint",


### PR DESCRIPTION
### Description

In https://github.com/Jahia/javascript-modules/pull/407, the `template/` folder and its content got moved to `templates/` but the `package.json` did not get updated accordingly.
Leading to an incomplete package:
![image](https://github.com/user-attachments/assets/4a7321cd-63c0-4c12-ab0e-9234368bb608)



> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
