### PR TITLE
fix: use same encoding as request for GQL queries

### DIFF
--- a/javascript-modules-engine/tests/cypress/e2e/ui/gqlTest.cy.ts
+++ b/javascript-modules-engine/tests/cypress/e2e/ui/gqlTest.cy.ts
@@ -17,7 +17,7 @@ describe("Test GQL", () => {
         properties: [
           { name: "jcr:title", value: "test component" },
           { name: "prop1", value: "prop1 value" },
-          { name: "prop2", value: "prop2 value" },
+          { name: "prop2", value: "prop2 value !@#$%ˆ//{}È" },
           {
             name: "propRichText",
             value: '<p data-testid="propRichTextValue">Hello this is a sample rich text</p>',
@@ -35,7 +35,7 @@ describe("Test GQL", () => {
     cy.get('li[data-testid="j:nodename"]').should("contain", "test");
     cy.get('li[data-testid="jcr:title"]').should("contain", "test component");
     cy.get('li[data-testid="prop1"]').should("contain", "prop1 value");
-    cy.get('li[data-testid="prop2"]').should("contain", "prop2 value");
+    cy.get('li[data-testid="prop2"]').should("contain", "prop2 value !@#$%ˆ//{}È");
     cy.get('li[data-testid="propRichText"]').should("contain", "Hello this is a sample rich text");
   });
 });


### PR DESCRIPTION
### Description
Use the request encoding (or `UTF-8` as default) for grqphQL queries from the `useGQLQuery` component. 

A Cypress test have been updated to ensure encoding is done properly. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
