### PR TITLE
refactor: use a custom element for raw html wrapping

### DIFF
--- a/javascript-modules-engine/src/javascript/react/init.tsx
+++ b/javascript-modules-engine/src/javascript/react/init.tsx
@@ -46,22 +46,25 @@ export default () => {
         </StyleRegistry>
       );
 
-      // Some server side components are using dangerouslySetInnerHTML to render their content,
-      // we need to clean the output to avoid having unwanted divs in the final output (e.g. <unwanteddiv>content</unwanteddiv>)
-      const cleanedRenderedElement = ReactDOMServer.renderToString(element)
-        .replace(/<unwanteddiv>/g, "")
-        .replace(/<\/unwanteddiv>/g, "");
+      const html = ReactDOMServer.renderToString(element)
+        // We use a `<jsm-raw-html>` element to wrap raw HTML output because React does not allow
+        // directly returning raw HTML strings. These elements are removed there, to avoid
+        // having them in the final output.
+        // `<jsm-raw-html>` SHOULD NOT be used in userland code, it is an internal implementation
+        // detail.
+        .replaceAll(/<\/?jsm-raw-html>/g, "");
 
       const styles = ReactDOMServer.renderToStaticMarkup(styleRegistry.styles());
       const stylesResource = styles
         ? `<jahia:resource type="inline" key="styles${props.id}">${styles}</jahia:resource>`
         : "";
+
       if (currentResource.getContextConfiguration() === "page") {
         // Set the HTML5 doctype that can't be rendered in JSX
-        return `<!DOCTYPE html>${cleanedRenderedElement}${stylesResource}`;
+        return `<!DOCTYPE html>${html}${stylesResource}`;
       }
 
-      return `${cleanedRenderedElement}${stylesResource}`;
+      return `${html}${stylesResource}`;
     },
   });
 };

--- a/javascript-modules-engine/tests/cypress/e2e/ui/renderTest.cy.ts
+++ b/javascript-modules-engine/tests/cypress/e2e/ui/renderTest.cy.ts
@@ -1,6 +1,6 @@
 import { addNode, enableModule } from "@jahia/cypress";
 import { addSimplePage } from "../../utils/helpers";
-import { GENERIC_SITE_KEY } from '../../support/constants';
+import { GENERIC_SITE_KEY } from "../../support/constants";
 
 describe("Test on render and createContentButtons helpers", () => {
   const pageName = "testRender";
@@ -23,8 +23,12 @@ describe("Test on render and createContentButtons helpers", () => {
     });
   });
 
-  beforeEach('Login', () => { cy.login(); });
-  afterEach('Logout', () => { cy.logout(); });
+  beforeEach("Login", () => {
+    cy.login();
+  });
+  afterEach("Logout", () => {
+    cy.logout();
+  });
 
   it(`${pageName}: should display page composer create button correctly using createContentButtons helper`, function () {
     cy.visit(`/jahia/jcontent/${GENERIC_SITE_KEY}/en/pages/home/${pageName}`);
@@ -38,7 +42,7 @@ describe("Test on render and createContentButtons helpers", () => {
   it(`${pageName}: should render jnt:text JSON node`, function () {
     cy.visit(`/cms/render/default/en/sites/${GENERIC_SITE_KEY}/home/${pageName}.html`);
     cy.get('div[data-testid="component-text-json-node"]').should("contain", "JSON node rendered");
-    cy.get("unwanteddiv").should("not.exist");
+    cy.get("jsm-raw-html").should("not.exist");
   });
 
   it(`${pageName}: should render jnt:text JSON node in config: OPTION`, function () {
@@ -47,7 +51,7 @@ describe("Test on render and createContentButtons helpers", () => {
       "contain",
       "JSON node rendered with option config",
     );
-    cy.get("unwanteddiv").should("not.exist");
+    cy.get("jsm-raw-html").should("not.exist");
   });
 
   it(`${pageName}: should render javascriptExample:test JSON node in config: OPTION with view: sub`, function () {
@@ -56,20 +60,20 @@ describe("Test on render and createContentButtons helpers", () => {
       "contain",
       "prop1 value it is",
     );
-    cy.get("unwanteddiv").should("not.exist");
+    cy.get("jsm-raw-html").should("not.exist");
   });
 
   it(`${pageName}: should render JSON node with INCLUDE config`, function () {
     cy.visit(`/cms/render/default/en/sites/${GENERIC_SITE_KEY}/home/${pageName}.html`);
     cy.get('div[data-testid="component-react-node-include"]').should("contain", "prop1 value");
-    cy.get("unwanteddiv").should("not.exist");
+    cy.get("jsm-raw-html").should("not.exist");
   });
 
   it(`${pageName}: should render JSON node with mixin`, function () {
     cy.visit(`/cms/render/default/en/sites/${GENERIC_SITE_KEY}/home/${pageName}.html`);
     cy.get('div[data-testid="component-json-node-with-mixin"]').should("contain", "tag1");
     cy.get('div[data-testid="component-json-node-with-mixin"]').should("contain", "tag2");
-    cy.get("unwanteddiv").should("not.exist");
+    cy.get("jsm-raw-html").should("not.exist");
   });
 
   it(`${pageName}: should render JSON node with parameters passed to render`, function () {
@@ -83,7 +87,7 @@ describe("Test on render and createContentButtons helpers", () => {
     cy.get(
       'div[data-testid="component-json-node-with-parameters"] div[data-testid="renderParam-notString-notSupported"]',
     ).should("contain", "objectParam not supported=");
-    cy.get("unwanteddiv").should("not.exist");
+    cy.get("jsm-raw-html").should("not.exist");
   });
 
   it(`${pageName}: should render node with parameters passed to render`, function () {
@@ -97,7 +101,7 @@ describe("Test on render and createContentButtons helpers", () => {
     cy.get(
       'div[data-testid="component-react-node-with-parameters"] div[data-testid="renderParam-notString-notSupported"]',
     ).should("contain", "objectParam not supported=");
-    cy.get("unwanteddiv").should("not.exist");
+    cy.get("jsm-raw-html").should("not.exist");
   });
 
   it(`${pageName}: should render existing child node using relative path`, function () {
@@ -114,6 +118,6 @@ describe("Test on render and createContentButtons helpers", () => {
       "contain",
       "Child node rendered using relative path",
     );
-    cy.get("unwanteddiv").should("not.exist");
+    cy.get("jsm-raw-html").should("not.exist");
   });
 });

--- a/javascript-modules-library/src/components/AbsoluteArea.tsx
+++ b/javascript-modules-library/src/components/AbsoluteArea.tsx
@@ -1,7 +1,8 @@
-import type React from "react";
-import { useServerContext } from "../hooks/useServerContext.js";
-import server from "virtual:jahia-server";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
+import type React from "react";
+import { createElement } from "react";
+import server from "virtual:jahia-server";
+import { useServerContext } from "../hooks/useServerContext.js";
 
 /**
  * Generates an absolute area in which editors may insert content objects.
@@ -54,25 +55,22 @@ export function AbsoluteArea({
   parameters?: Record<string, unknown>;
 }>): React.JSX.Element {
   const { renderContext } = useServerContext();
-  return (
-    // @ts-expect-error <unwanteddiv> is not a valid HTML element
-    <unwanteddiv
-      dangerouslySetInnerHTML={{
-        __html: server.render.renderAbsoluteArea(
-          {
-            name,
-            parent: parent,
-            view,
-            allowedNodeTypes,
-            numberOfItems,
-            nodeType,
-            editable: readOnly !== true,
-            limitedAbsoluteAreaEdit: readOnly === "children",
-            parameters,
-          },
-          renderContext,
-        ),
-      }}
-    />
-  );
+  return createElement("jsm-raw-html", {
+    dangerouslySetInnerHTML: {
+      __html: server.render.renderAbsoluteArea(
+        {
+          name,
+          parent: parent,
+          view,
+          allowedNodeTypes,
+          numberOfItems,
+          nodeType,
+          editable: readOnly !== true,
+          limitedAbsoluteAreaEdit: readOnly === "children",
+          parameters,
+        },
+        renderContext,
+      ),
+    },
+  });
 }

--- a/javascript-modules-library/src/components/AddContentButtons.tsx
+++ b/javascript-modules-library/src/components/AddContentButtons.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "react";
+import { createElement, type JSX } from "react";
 import server from "virtual:jahia-server";
 import { useServerContext } from "../hooks/useServerContext.js";
 
@@ -47,21 +47,18 @@ export function AddContentButtons({
   editCheck?: boolean;
 }>): JSX.Element {
   const { renderContext, currentResource } = useServerContext();
-  return (
-    // @ts-expect-error <unwanteddiv> is not a valid HTML element
-    <unwanteddiv
-      dangerouslySetInnerHTML={{
-        __html: server.render.createContentButtons(
-          childName,
-          // The render produces a ModuleTag instance under the hood
-          // (<template:module nodeTypes="type1 type2 type3" /> in JSP),
-          // it expects a string with the node types separated by a space.
-          nodeTypes.join(" "),
-          editCheck,
-          renderContext,
-          currentResource,
-        ),
-      }}
-    />
-  );
+  return createElement("jsm-raw-html", {
+    dangerouslySetInnerHTML: {
+      __html: server.render.createContentButtons(
+        childName,
+        // The render produces a ModuleTag instance under the hood
+        // (<template:module nodeTypes="type1 type2 type3" /> in JSP),
+        // it expects a string with the node types separated by a space.
+        nodeTypes.join(" "),
+        editCheck,
+        renderContext,
+        currentResource,
+      ),
+    },
+  });
 }

--- a/javascript-modules-library/src/components/AddResources.tsx
+++ b/javascript-modules-library/src/components/AddResources.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "react";
+import { createElement, type JSX } from "react";
 import server from "virtual:jahia-server";
 import { useServerContext } from "../hooks/useServerContext.js";
 
@@ -67,12 +67,9 @@ export function AddResources(
   }>,
 ): JSX.Element {
   const { renderContext } = useServerContext();
-  return (
-    // @ts-expect-error <unwanteddiv> is not a valid HTML element
-    <unwanteddiv
-      dangerouslySetInnerHTML={{
-        __html: server.render.addResources(props, renderContext),
-      }}
-    />
-  );
+  return createElement("jsm-raw-html", {
+    dangerouslySetInnerHTML: {
+      __html: server.render.addResources(props, renderContext),
+    },
+  });
 }

--- a/javascript-modules-library/src/components/Area.tsx
+++ b/javascript-modules-library/src/components/Area.tsx
@@ -1,6 +1,6 @@
-import type { JSX } from "react";
-import { useServerContext } from "../hooks/useServerContext.js";
+import { createElement, type JSX } from "react";
 import server from "virtual:jahia-server";
+import { useServerContext } from "../hooks/useServerContext.js";
 
 /**
  * Generates an area in which editors may insert content objects.
@@ -44,23 +44,20 @@ export function Area({
   parameters?: Record<string, unknown>;
 }>): JSX.Element {
   const { renderContext } = useServerContext();
-  return (
-    // @ts-expect-error <unwanteddiv> is not a valid HTML element
-    <unwanteddiv
-      dangerouslySetInnerHTML={{
-        __html: server.render.renderArea(
-          {
-            name,
-            view,
-            allowedNodeTypes,
-            numberOfItems,
-            nodeType,
-            editable: !readOnly,
-            parameters,
-          },
-          renderContext,
-        ),
-      }}
-    />
-  );
+  return createElement("jsm-raw-html", {
+    dangerouslySetInnerHTML: {
+      __html: server.render.renderArea(
+        {
+          name,
+          view,
+          allowedNodeTypes,
+          numberOfItems,
+          nodeType,
+          editable: !readOnly,
+          parameters,
+        },
+        renderContext,
+      ),
+    },
+  });
 }

--- a/javascript-modules-library/src/components/render/Render.tsx
+++ b/javascript-modules-library/src/components/render/Render.tsx
@@ -1,6 +1,8 @@
+import type { JCRNodeWrapper } from "org.jahia.services.content";
+import type React from "react";
+import { createElement } from "react";
 import server from "virtual:jahia-server";
 import { useServerContext } from "../../hooks/useServerContext.js";
-import type { JCRNodeWrapper } from "org.jahia.services.content";
 
 /**
  * Render a content node
@@ -42,25 +44,22 @@ export function Render({
   parameters?: unknown;
 }>): React.JSX.Element {
   const { renderContext, currentResource } = useServerContext();
-  return (
-    // @ts-expect-error <unwanteddiv> is not a valid HTML element
-    <unwanteddiv
-      dangerouslySetInnerHTML={{
-        __html: server.render.render(
-          {
-            content,
-            node,
-            path,
-            editable: !readOnly,
-            advanceRenderingConfig,
-            templateType,
-            view,
-            parameters,
-          },
-          renderContext,
-          currentResource,
-        ),
-      }}
-    />
-  );
+  return createElement("jsm-raw-html", {
+    dangerouslySetInnerHTML: {
+      __html: server.render.render(
+        {
+          content,
+          node,
+          path,
+          editable: !readOnly,
+          advanceRenderingConfig,
+          templateType,
+          view,
+          parameters,
+        },
+        renderContext,
+        currentResource,
+      ),
+    },
+  });
 }


### PR DESCRIPTION
### Description

Use a custom element (prefixed with `jsm-`) to avoid potential conflicts and type errors.

Peer PR: https://github.com/Jahia/luxe-jahia-demo/pull/270



### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
