### PR TITLE
ci: single node install and yarn build

### DIFF
--- a/jahia-test-module/pom.xml
+++ b/jahia-test-module/pom.xml
@@ -1,4 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    >
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>javascript-modules</artifactId>
@@ -11,8 +15,11 @@
     <description>Test module for Javascript Module Engine</description>
 
     <dependencies>
-        <!-- the dependencies towards other modules of the mono-repo listed in the package.json should be listed here as well (so the Maven Reactor can determine the build order of the modules) -->
-        <!-- TODO create/use a Maven plugin to convert the package.json dependencies into Maven dependencies -->
+        <!-- the dependencies towards other modules of the mono-repo listed in the package.json
+        should be listed here as well (so the Maven Reactor can determine the build order of the
+        modules) -->
+        <!-- TODO create/use a Maven plugin to convert the package.json dependencies into Maven
+        dependencies -->
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>vite-plugin</artifactId>
@@ -38,43 +45,12 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <executions>
-                    <!-- Executions bound on the "initialize" phase (executed in order of declaration): -->
-                    <execution>
-                        <id>install node and yarn</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn install</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                    </execution>
-                    <!-- Executions bound on the "package" phase (executed in order of declaration): -->
-                    <execution>
-                        <id>yarn pack</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>build</arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <!-- attach the dist/package.tgz artifact to the Maven build so it will be installed/deployed as part of the Maven build -->
+                        <!-- attach the dist/package.tgz artifact to the Maven build so it will be
+                        installed/deployed as part of the Maven build -->
                         <!-- bound to the "package" phase -->
                         <id>attach-tgz-artifact</id>
                         <goals>
@@ -95,7 +71,9 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <!-- copy the dist/package.tgz to the target directory with the finalName of the Maven build in the target/ folder so it is found by the CI when looking for jars to install before running integration tests -->
+                        <!-- copy the dist/package.tgz to the target directory with the finalName of
+                        the Maven build in the target/ folder so it is found by the CI when looking
+                        for jars to install before running integration tests -->
                         <id>copy-dist-package</id>
                         <phase>package</phase>
                         <goals>
@@ -103,7 +81,10 @@
                         </goals>
                         <configuration>
                             <target>
-                                <copy file="dist/package.tgz" tofile="${project.build.directory}/${project.build.finalName}.tgz" />
+                                <copy
+                                    file="dist/package.tgz"
+                                    tofile="${project.build.directory}/${project.build.finalName}.tgz"
+                                    />
                             </target>
                         </configuration>
                     </execution>

--- a/javascript-create-module/pom.xml
+++ b/javascript-create-module/pom.xml
@@ -1,4 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    >
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>javascript-modules</artifactId>
@@ -29,20 +33,6 @@
                 <!-- Map Yarn commands to corresponding Maven phases -->
                 <executions>
                     <execution>
-                        <id>install node and yarn</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn install</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>yarn lint</id>
                         <phase>compile</phase>
                         <goals>
@@ -50,16 +40,6 @@
                         </goals>
                         <configuration>
                             <arguments>lint</arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>yarn pack</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>build</arguments>
                         </configuration>
                     </execution>
                     <execution>
@@ -79,7 +59,9 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
-                            <arguments>node ../.m2/sync-version.js ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-alpha-${timestamp}</arguments>
+                            <arguments>
+                                node ../.m2/sync-version.js
+                                ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-alpha-${timestamp}</arguments>
                         </configuration>
                     </execution>
                     <execution>
@@ -134,7 +116,8 @@
         </profile>
         <profile>
             <id>release-perform</id>
-            <!-- publish the tgz during the release:perform task (i.e. when the profile "release-perform" is enabled) -->
+            <!-- publish the tgz during the release:perform task (i.e. when the profile
+            "release-perform" is enabled) -->
             <build>
                 <plugins>
                     <plugin>

--- a/javascript-modules-engine-java/pom.xml
+++ b/javascript-modules-engine-java/pom.xml
@@ -1,22 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-   Copyright (C) 2002-2024 Jahia Solutions Group SA. All rights reserved.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    >
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>javascript-modules</artifactId>
@@ -139,7 +126,8 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- dependencies that should be embedded in the final bundle as they are not provided by Jahia: -->
+        <!-- dependencies that should be embedded in the final bundle as they are not provided by
+        Jahia: -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
@@ -157,7 +145,8 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- dependencies exposed in the TypeScript Type Declaration files (*.d.ts), but not used in Java: -->
+        <!-- dependencies exposed in the TypeScript Type Declaration files (*.d.ts), but not used in
+        Java: -->
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-spi-commons</artifactId>
@@ -210,8 +199,14 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${project.build.directory}/java-ts-bind/sources" />
-                                <get src="https://codeload.github.com/openjdk/jdk17u/zip/refs/heads/master" dest="${project.build.directory}/java-ts-bind/sources/jdk17u-master.zip" />
-                                <unzip src="${project.build.directory}/java-ts-bind/sources/jdk17u-master.zip" dest="${project.build.directory}/java-ts-bind/sources">
+                                <get
+                                    src="https://codeload.github.com/openjdk/jdk17u/zip/refs/heads/master"
+                                    dest="${project.build.directory}/java-ts-bind/sources/jdk17u-master.zip"
+                                    />
+                                <unzip
+                                    src="${project.build.directory}/java-ts-bind/sources/jdk17u-master.zip"
+                                    dest="${project.build.directory}/java-ts-bind/sources"
+                                    >
                                     <patternset>
                                         <include name="jdk17u-master/src/java.base/share/classes/**" />
                                     </patternset>
@@ -233,14 +228,11 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>
-                                jahia-impl,
-                                javax.servlet-api,
-                                jcr,
-                                org.apache.felix.framework
-                            </includeArtifactIds>
+                            <includeArtifactIds> jahia-impl, javax.servlet-api, jcr,
+                                org.apache.felix.framework </includeArtifactIds>
                             <classifier>sources</classifier>
-                            <outputDirectory>${project.build.directory}/java-ts-bind/sources/dependencies
+                            <outputDirectory>
+                                ${project.build.directory}/java-ts-bind/sources/dependencies
                             </outputDirectory>
                         </configuration>
                     </execution>
@@ -251,9 +243,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>
-                                java-ts-bind
-                            </includeArtifactIds>
+                            <includeArtifactIds> java-ts-bind </includeArtifactIds>
                             <classifier>all</classifier>
                             <outputDirectory>${project.build.directory}/java-ts-bind/exec</outputDirectory>
                             <stripVersion>true</stripVersion>
@@ -266,19 +256,9 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>
-                                commons-lang3,
-                                graal-sdk,
-                                jackrabbit-spi-commons,
-                                jahia-impl,
-                                javax.servlet-api,
-                                jboss-servlet-api_3.1_spec,
-                                jcr,
-                                org.apache.felix.framework,
-                                osgi.annotation,
-                                pax-web-jsp,
-                                xml-apis
-                            </includeArtifactIds>
+                            <includeArtifactIds> commons-lang3, graal-sdk, jackrabbit-spi-commons,
+                                jahia-impl, javax.servlet-api, jboss-servlet-api_3.1_spec, jcr,
+                                org.apache.felix.framework, osgi.annotation, pax-web-jsp, xml-apis </includeArtifactIds>
                             <outputDirectory>${project.build.directory}/java-ts-bind/jars</outputDirectory>
                             <stripVersion>true</stripVersion>
                         </configuration>
@@ -294,11 +274,12 @@
                                 <ignoredUnusedDeclaredDependency>org.springframework:spring-webmvc</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>javax.servlet:jstl</ignoredUnusedDeclaredDependency>
                                 <!-- used to generate *.d.ts from Java code: -->
-                                <ignoredUnusedDeclaredDependency>io.github.bensku:java-ts-bind
-                                </ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>io.github.bensku:java-ts-bind </ignoredUnusedDeclaredDependency>
                                 <!-- only exposed in *.d.ts files, not used in Java: -->
-                                <ignoredUnusedDeclaredDependency>org.apache.jackrabbit:jackrabbit-spi-commons</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>
+                                    org.apache.jackrabbit:jackrabbit-spi-commons</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>
+                                    org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.osgi:osgi.annotation</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>xml-apis:xml-apis</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
@@ -313,9 +294,12 @@
                 <executions>
                     <execution>
                         <id>generate-d.ts-files-from-java</id>
-                        <!-- important to be executed between the "process-classes" and the "package" phases: -->
-                        <!-- the "process-classes" phase is when the .jar file with the classes is created (which is required by java-ts-bind in this execution) -->
-                        <!-- the "package" phase is when the .tgz file is created with the *.d.ts files generated here -->
+                        <!-- important to be executed between the "process-classes" and the
+                        "package" phases: -->
+                        <!-- the "process-classes" phase is when the .jar file with the classes is
+                        created (which is required by java-ts-bind in this execution) -->
+                        <!-- the "package" phase is when the .tgz file is created with the *.d.ts
+                        files generated here -->
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>exec</goal>
@@ -324,7 +308,8 @@
                             <executable>java</executable>
                             <arguments>
                                 <argument>-jar</argument>
-                                <argument>${project.basedir}/target/java-ts-bind/exec/java-ts-bind-all.jar</argument>
+                                <argument>
+                                    ${project.basedir}/target/java-ts-bind/exec/java-ts-bind-all.jar</argument>
                                 <argument>--packageJson</argument>
                                 <argument>${project.basedir}/.java-ts-bind/package.json</argument>
                             </arguments>
@@ -362,7 +347,8 @@
                     </execution>
                     <execution>
                         <!-- package the typescript *.d.ts files that have been previously generated -->
-                        <!-- NB: the generated .tgz file will be attached to the project and will be installed/deployed along with the .jar file -->
+                        <!-- NB: the generated .tgz file will be attached to the project and will be
+                        installed/deployed along with the .jar file -->
                         <id>package-typescript-types-tgz</id>
                         <phase>package</phase>
                         <goals>

--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -1,22 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-   Copyright (C) 2002-2024 Jahia Solutions Group SA. All rights reserved.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!-- Copyright (C) 2002-2024 Jahia Solutions Group SA. All rights reserved. Licensed under the
+Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless
+required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License. -->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    >
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>javascript-modules</artifactId>
@@ -56,10 +50,12 @@
                 <configuration>
                     <instructions>
                         <_dsannotations>*</_dsannotations>
-                        <!-- those OSGI dependencies are not provided by Jahia and should be embedded in the bundle -->
+                        <!-- those OSGI dependencies are not provided by Jahia and should be
+                        embedded in the bundle -->
                         <Embed-Dependency>bndlib,commons-pool2,pax-swissbox-bnd</Embed-Dependency>
                     </instructions>
-                    <!-- because the Java classes of javascript-modules-engine-java are unpacked into the target/classes folder, -->
+                    <!-- because the Java classes of javascript-modules-engine-java are unpacked
+                    into the target/classes folder, -->
                     <!-- the dependency can and should be excluded to avoid duplicates -->
                     <excludeDependencies>javascript-modules-engine-java</excludeDependencies>
                 </configuration>
@@ -84,7 +80,8 @@
                 <executions>
                     <execution>
                         <id>unpack-javascript-modules-engine-java</id>
-                        <!-- unzip the .jar with the Java classes so from an OSGI standpoint, it's equivalent to have the Java sources in this module -->
+                        <!-- unzip the .jar with the Java classes so from an OSGI standpoint, it's
+                        equivalent to have the Java sources in this module -->
                         <phase>process-resources</phase>
                         <goals>
                             <goal>unpack</goal>
@@ -102,41 +99,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <configuration>
-                    <environmentVariables>
-                        <NODE_OPTIONS>--openssl-legacy-provider</NODE_OPTIONS>
-                    </environmentVariables>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>npm install node and yarn</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn install</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn post-install</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>${yarn-build}</arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
@@ -178,8 +140,9 @@
                 <plugins>
                     <plugin>
                         <!-- by default on CI environment, yarn has the "immutable" option set -->
-                        <!-- however, during the release preparation process (i.e. with the "release-prepare" profile enabled),
-                        it must be explicitly disabled to recompute the checksums in the yarn.lock files after the version change -->
+                        <!-- however, during the release preparation process (i.e. with the
+                        "release-prepare" profile enabled), it must be explicitly disabled to
+                        recompute the checksums in the yarn.lock files after the version change -->
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
                         <configuration>

--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (C) 2002-2024 Jahia Solutions Group SA. All rights reserved. Licensed under the
-Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
-License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless
-required by applicable law or agreed to in writing, software distributed under the License is
-distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied. See the License for the specific language governing permissions and limitations under the
-License. -->
 <project
     xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/javascript-modules-library/pom.xml
+++ b/javascript-modules-library/pom.xml
@@ -1,4 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    >
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>javascript-modules</artifactId>
@@ -36,20 +40,6 @@
                 <!-- Map Yarn commands to corresponding Maven phases -->
                 <executions>
                     <execution>
-                        <id>install node and yarn</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn install</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>yarn lint</id>
                         <phase>compile</phase>
                         <goals>
@@ -60,23 +50,15 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>yarn build</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>build</arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>set-alpha-version</id>
                         <phase>deploy</phase>
                         <goals>
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
-                            <arguments>node ../.m2/sync-version.js ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-alpha-${timestamp}</arguments>
+                            <arguments>
+                                node ../.m2/sync-version.js
+                                ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-alpha-${timestamp}</arguments>
                         </configuration>
                     </execution>
                     <execution>
@@ -111,13 +93,10 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>
-                                javascript-modules-engine-java
-                            </includeArtifactIds>
+                            <includeArtifactIds> javascript-modules-engine-java </includeArtifactIds>
                             <classifier>typescript-types</classifier>
                             <type>tgz</type>
-                            <outputDirectory>${project.build.directory}/types
-                            </outputDirectory>
+                            <outputDirectory>${project.build.directory}/types </outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -152,7 +131,8 @@
         </profile>
         <profile>
             <id>release-perform</id>
-            <!-- publish the tgz during the release:perform task (i.e. when the profile "release-perform" is enabled) -->
+            <!-- publish the tgz during the release:perform task (i.e. when the profile
+            "release-perform" is enabled) -->
             <build>
                 <plugins>
                     <plugin>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "vite-plugin"
   ],
   "scripts": {
-    "build": "yarn workspaces foreach -Atvv run build",
+    "build": "yarn workspaces foreach -Avv --topological-dev run build",
     "format": "prettier --write --list-different $INIT_CWD",
     "lint": "eslint $INIT_CWD"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "vite-plugin"
   ],
   "scripts": {
+    "build": "yarn workspaces foreach -Atvv run build",
     "format": "prettier --write --list-different $INIT_CWD",
     "lint": "eslint $INIT_CWD"
   },

--- a/pom.xml
+++ b/pom.xml
@@ -1,22 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-   Copyright (C) 2002-2024 Jahia Solutions Group SA. All rights reserved.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    >
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>jahia-modules</artifactId>
@@ -51,9 +38,11 @@
     </modules>
 
     <properties>
-        <!-- override the version of org.sonatype.plugins:nexus-staging-maven-plugin to ensure compatibility with JDK 17 -->
+        <!-- override the version of org.sonatype.plugins:nexus-staging-maven-plugin to ensure
+        compatibility with JDK 17 -->
         <nexus.maven.plugin.version>1.7.0</nexus.maven.plugin.version>
-        <!-- frontend-maven-plugin requires to use yarn 1.22.x as a "bootstrap" but then, the .yarnrc.yml will be detected and Yarn Berry (4+) will be used -->
+        <!-- frontend-maven-plugin requires to use yarn 1.22.x as a "bootstrap" but then, the
+        .yarnrc.yml will be detected and Yarn Berry (4+) will be used -->
         <frontend-maven-plugin.yarn.version>v1.22.22</frontend-maven-plugin.yarn.version>
         <frontend-maven-plugin.node.version>v22.10.0</frontend-maven-plugin.node.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
@@ -109,12 +98,14 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.9.4</version> <!-- matches https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L144 -->
+                <version>1.9.4</version> <!-- matches
+                https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L144 -->
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.14.0</version> <!-- matches https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L154 -->
+                <version>2.14.0</version> <!-- matches
+                https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L154 -->
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -124,32 +115,38 @@
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
-                <version>3.0.2</version> <!-- matches https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L1742 -->
+                <version>3.0.2</version> <!-- matches
+                https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L1742 -->
             </dependency>
             <dependency>
                 <groupId>javax.el</groupId>
                 <artifactId>javax.el-api</artifactId>
-                <version>3.0.0-jahia1</version> <!-- matches https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/features/core/pom.xml#L85 -->
+                <version>3.0.0-jahia1</version> <!-- matches
+                https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/features/core/pom.xml#L85 -->
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
-                <version>1</version>  <!-- matches https://github.com/Jahia/jahia-private/blob/JAHIA_8_2_1_0/war/src/data/resources/karaf/etc/custom.properties#L401 -->
+                <version>1</version>  <!-- matches
+                https://github.com/Jahia/jahia-private/blob/JAHIA_8_2_1_0/war/src/data/resources/karaf/etc/custom.properties#L401 -->
             </dependency>
             <dependency>
                 <groupId>javax.jcr</groupId>
                 <artifactId>jcr</artifactId>
-                <version>2.0</version> <!-- matches https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L457 -->
+                <version>2.0</version> <!-- matches
+                https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L457 -->
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.25.0</version> <!-- matches https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L144 -->
+                <version>1.25.0</version> <!-- matches
+                https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L144 -->
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version> <!-- matches https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L175 -->
+                <version>3.12.0</version> <!-- matches
+                https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L175 -->
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -189,7 +186,8 @@
             <dependency>
                 <groupId>org.ops4j.pax.web</groupId>
                 <artifactId>pax-web-jsp</artifactId>
-                <version>7.3.29-jahia2</version> <!-- matches https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/jahia-parent/pom.xml#L179 -->
+                <version>7.3.29-jahia2</version> <!-- matches
+                https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/jahia-parent/pom.xml#L179 -->
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
@@ -209,7 +207,8 @@
             <dependency>
                 <groupId>pl.touk</groupId>
                 <artifactId>throwing-function</artifactId>
-                <version>1.3</version> <!--matches https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L807 -->
+                <version>1.3</version> <!--matches
+                https://github.com/Jahia/jahia/blob/JAHIA_8_2_1_0/core/pom.xml#L807 -->
             </dependency>
 
             <!-- test dependencies: -->
@@ -318,8 +317,10 @@
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
-                    <!-- when releasing, the checksum of the javascript-modules-library package in the yarn.lock files changes -->
-                    <!-- 'clean verify/install' is used to recompute the checksum of the yarn.lock files as part of the regular Maven build -->
+                    <!-- when releasing, the checksum of the javascript-modules-library package in
+                    the yarn.lock files changes -->
+                    <!-- 'clean verify/install' is used to recompute the checksum of the yarn.lock
+                    files as part of the regular Maven build -->
                     <!-- scm:checkin allows to commit those files -->
                     <preparationGoals>-P release-prepare clean verify scm:checkin</preparationGoals>
                     <completionGoals>-P release-prepare clean install scm:checkin</completionGoals>
@@ -332,11 +333,9 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <!-- extract the components of the version in Maven variables:
-                            - ${parsedVersion.majorVersion}
-                            - ${parsedVersion.minorVersion}
-                            - ${parsedVersion.incrementalVersion}
-                        -->
+                        <!-- extract the components of the version in Maven variables: -
+                        ${parsedVersion.majorVersion} - ${parsedVersion.minorVersion} -
+                        ${parsedVersion.incrementalVersion} -->
                         <goals>
                             <goal>parse-version</goal>
                         </goals>
@@ -355,10 +354,45 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <!-- use UTC to ensure the timestamps between 2 builds are in the correct SemVer order -->
+                    <!-- use UTC to ensure the timestamps between 2 builds are in the correct SemVer
+                    order -->
                     <timestampFormat>yyyyMMddHHmmssSSS</timestampFormat>
                     <timezone>UTC</timezone>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>${frontend-maven-plugin.version}</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <nodeVersion>${frontend-maven-plugin.node.version}</nodeVersion>
+                    <yarnVersion>${frontend-maven-plugin.yarn.version}</yarnVersion>
+                    <installDirectory>target</installDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install node and yarn</id>
+                        <goals>
+                            <goal>install-node-and-yarn</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>yarn install</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>yarn build</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -371,8 +405,7 @@
                         <artifactId>maven-scm-plugin</artifactId>
                         <configuration>
                             <includes>
-                                javascript-modules-engine/yarn.lock,jahia-test-module/yarn.lock
-                            </includes>
+                                javascript-modules-engine/yarn.lock,jahia-test-module/yarn.lock </includes>
                             <message>chore(release): Prepare release ${project.version}</message>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,7 @@
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>${frontend-maven-plugin.version}</version>
+                <!-- This repo is a JS monorepo, we only need to install and build once at the root -->
                 <inherited>false</inherited>
                 <configuration>
                     <nodeVersion>${frontend-maven-plugin.node.version}</nodeVersion>

--- a/samples/hydrogen/pom.xml
+++ b/samples/hydrogen/pom.xml
@@ -1,4 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    >
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>javascript-modules</artifactId>
@@ -28,22 +32,8 @@
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <executions>
-                    <!-- Executions bound on the "initialize" phase (executed in order of declaration): -->
-                    <execution>
-                        <id>install node and yarn - Hydrogen</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn install - Hydrogen</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                    </execution>
-                    <!-- Executions bound on the "process-sources" phase (executed in order of declaration): -->
+                    <!-- Executions bound on the "process-sources" phase (executed in order of
+                    declaration): -->
                     <execution>
                         <id>yarn lint - Hydrogen</id>
                         <phase>process-sources</phase>
@@ -54,17 +44,6 @@
                             <arguments>lint</arguments>
                         </configuration>
                     </execution>
-                    <!-- Executions bound on the "package" phase (executed in order of declaration): -->
-                    <execution>
-                        <id>yarn pack - Hydrogen</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>build</arguments>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -72,7 +51,8 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <!-- attach the dist/package.tgz artifact to the Maven build so it will be installed/deployed as part of the Maven build -->
+                        <!-- attach the dist/package.tgz artifact to the Maven build so it will be
+                        installed/deployed as part of the Maven build -->
                         <!-- bound to the "package" phase -->
                         <id>attach-tgz-artifact</id>
                         <goals>
@@ -93,7 +73,9 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <!-- copy the dist/package.tgz to the target directory with the finalName of the Maven build in the target/ folder so it is found by the CI when looking for jars to install before running integration tests -->
+                        <!-- copy the dist/package.tgz to the target directory with the finalName of
+                        the Maven build in the target/ folder so it is found by the CI when looking
+                        for jars to install before running integration tests -->
                         <id>copy-dist-package - Hydrogen</id>
                         <phase>package</phase>
                         <goals>
@@ -101,7 +83,10 @@
                         </goals>
                         <configuration>
                             <target>
-                                <copy file="dist/package.tgz" tofile="${project.build.directory}/${project.build.finalName}.tgz" />
+                                <copy
+                                    file="dist/package.tgz"
+                                    tofile="${project.build.directory}/${project.build.finalName}.tgz"
+                                    />
                             </target>
                         </configuration>
                     </execution>

--- a/vite-plugin/pom.xml
+++ b/vite-plugin/pom.xml
@@ -1,4 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    >
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>javascript-modules</artifactId>
@@ -28,30 +32,6 @@
                 <!-- Map Yarn commands to corresponding Maven phases -->
                 <executions>
                     <execution>
-                        <id>install node and yarn</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn install</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn build</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>build</arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>yarn test</id>
                         <phase>integration-test</phase>
                         <goals>
@@ -68,8 +48,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
-                            <arguments>
-                                node ../.m2/sync-version.js
+                            <arguments> node ../.m2/sync-version.js
                                 ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-alpha-${timestamp}</arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### Description

Before: one node installation and yarn build per package

<img width="521" height="152" alt="image" src="https://github.com/user-attachments/assets/492995a7-6665-4afa-b88d-a2cc57679aff" />


After: single node installation and yarn build at the monorepo root (Javascript Modules)

<img width="516" height="149" alt="image" src="https://github.com/user-attachments/assets/ab1411d0-c84c-4671-af60-5a7f8b9fe199" />


Why? Since all dependencies are installed at the root of the monorepo, there is no need to run `yarn install` in every sub-package. Yarn also ensures that all packages in the monorepo are built in the right order (--topological-dev flag) 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
