### PR TITLE
docs: use directives instead of gh-specific syntax

### DIFF
--- a/.github/workflows/push-docs.yml
+++ b/.github/workflows/push-docs.yml
@@ -1,3 +1,5 @@
+name: Push Docs to the Academy
+
 on:
   release:
     types: [published]

--- a/docs/1-getting-started/1-dev-environment/README.md
+++ b/docs/1-getting-started/1-dev-environment/README.md
@@ -31,8 +31,9 @@ Docker version 27.5.1, build 9f9e405
 
 It might work with other versions but we can't guarantee it. If you encounter any issues, please refer to the official documentation of the tools.
 
-> [!IMPORTANT]
-> Make sure you are running **Node 22.14 or later** by running `node -v`. You will need **Yarn 4.9** or later, which **should be managed by [Corepack](https://github.com/nodejs/corepack)**. Make sure to run `corepack enable yarn` to enable it. [You don't need a global installation of Yarn.](https://yarnpkg.com/getting-started/install)
+:::warning
+Make sure you are running **Node 22.14 or later** by running `node -v`. You will need **Yarn 4.9** or later, which **should be managed by [Corepack](https://github.com/nodejs/corepack)**. Make sure to run `corepack enable yarn` to enable it. [You don't need a global installation of Yarn.](https://yarnpkg.com/getting-started/install)
+:::
 
 ## Create a New Project
 

--- a/docs/1-getting-started/2-making-a-hero-section/README.md
+++ b/docs/1-getting-started/2-making-a-hero-section/README.md
@@ -48,8 +48,9 @@ You can stop and restart `yarn dev` to push this definition to your Jahia instan
 
 Click **New content** and select **heroSection** to create a new hero section:
 
-> [!WARNING]
-> Jahia will refuse your type definition if it contains a breaking change. During development, you can use the [Installed definitions browser](http://localhost:8080/modules/tools/definitionsBrowser.jsp) tool to remove your type definition and push a new one.
+:::warning
+Jahia will refuse your type definition if it contains a breaking change. During development, you can use the [Installed definitions browser](http://localhost:8080/modules/tools/definitionsBrowser.jsp) tool to remove your type definition and push a new one.
+:::
 
 ![Content insertion interface](create-hero-section.png)
 
@@ -266,9 +267,10 @@ Once pushed to your Jahia instance, if you create a CTA button in your hero sect
 
 You can add as many CTAs as you want to your hero section. This is why we haven't defined our CTA properties on `heroSection` directly: it allows for more flexibility and reusability.
 
-> [!TIP]
-> You can, at all times, take a look at your data tree with the [JCR repository browser](http://localhost:8080/modules/tools/jcrBrowser.jsp).
-> For instance, you should be able to find the content you created at the `sites/<site key>/home/main` path.
-> It can be useful to remove buggy nodes or to understand how your data is persisted.
+:::info
+You can, at all times, take a look at your data tree with the [JCR repository browser](http://localhost:8080/modules/tools/jcrBrowser.jsp).
+For instance, you should be able to find the content you created at the `sites/<site key>/home/main` path.
+It can be useful to remove buggy nodes or to understand how your data is persisted.
+:::
 
 Next: [The "About Us" Page](the-about-us-page)


### PR DESCRIPTION
### Description

Yay!

This will replace this weird text:

<img width="790" height="95" alt="image" src="https://github.com/user-attachments/assets/177da6ff-0283-450a-a893-67e549f0878e" />

With a nice warning box

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
