### PR TITLE
fix(vite-plugin): ensure all builds succeed before callback

### DIFF
--- a/vite-plugin/src/build-success.ts
+++ b/vite-plugin/src/build-success.ts
@@ -1,0 +1,29 @@
+import { Plugin } from "vite";
+
+/**
+ * List of environments still being built.
+ *
+ * This variable is in the global scope and shared between all instances of the plugin. This is
+ * because Vite intentionally creates a new instance of each plugin for each environment when
+ * running in multi-environment mode, to avoid breaking legacy plugins.
+ */
+const building = new Set<string>();
+
+/**
+ * Plugin to execute a callback when a build succeeds.
+ *
+ * It tracks the completion of builds in watch mode.
+ */
+export function buildSuccessPlugin(callback: () => void | Promise<void>): Plugin {
+  return {
+    name: "build-successful-callback",
+    buildStart() {
+      building.add(this.environment.name);
+    },
+    async closeBundle(error) {
+      if (error) return;
+      building.delete(this.environment.name);
+      if (building.size === 0) await callback();
+    },
+  };
+}

--- a/vite-plugin/src/build-success.ts
+++ b/vite-plugin/src/build-success.ts
@@ -1,4 +1,4 @@
-import { Plugin } from "vite";
+import type { Plugin } from "vite";
 
 /**
  * List of environments still being built.

--- a/vite-plugin/src/build-successful.ts
+++ b/vite-plugin/src/build-successful.ts
@@ -14,7 +14,7 @@ const building = new Set<string>();
  *
  * It tracks the completion of builds in watch mode.
  */
-export function buildSuccessPlugin(callback: () => void | Promise<void>): Plugin {
+export function buildSuccessful(callback: () => void | Promise<void>): Plugin {
   return {
     name: "build-successful-callback",
     buildStart() {

--- a/vite-plugin/src/index.ts
+++ b/vite-plugin/src/index.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { styleText } from "node:util";
 import { globSync } from "tinyglobby";
 import type { PluginOption } from "vite";
-import { buildSuccessPlugin } from "./build-success.js";
+import { buildSuccessful } from "./build-successful.js";
 import { insertFilename } from "./insert-filename.js";
 import { multiEntry } from "./multi-entry.js";
 
@@ -177,7 +177,7 @@ export default function jahia(
                   // Only add the callback plugin in watch mode
                   config.build?.watch &&
                     options.watchCallback &&
-                    buildSuccessPlugin(options.watchCallback),
+                    buildSuccessful(options.watchCallback),
                 ],
               },
             },
@@ -218,7 +218,7 @@ export default function jahia(
                   // Only add the callback plugin in watch mode
                   config.build?.watch &&
                     options.watchCallback &&
-                    buildSuccessPlugin(options.watchCallback),
+                    buildSuccessful(options.watchCallback),
                   // Insert filenames in client-side components
                   insertFilename(
                     clientBaseDir,

--- a/vite-plugin/src/index.ts
+++ b/vite-plugin/src/index.ts
@@ -1,21 +1,11 @@
 import { clientLibs, serverLibs } from "javascript-modules-engine/shared-libs.mjs";
 import path from "node:path";
 import { styleText } from "node:util";
-import type { Plugin } from "rollup";
 import { globSync } from "tinyglobby";
 import type { PluginOption } from "vite";
+import { buildSuccessPlugin } from "./build-success.js";
 import { insertFilename } from "./insert-filename.js";
 import { multiEntry } from "./multi-entry.js";
-
-/** Plugin to execute a callback when a build succeeds. */
-function buildSuccessPlugin(callback: () => void | Promise<void>): Plugin {
-  return {
-    name: "build-success-callback",
-    async closeBundle(error) {
-      if (!error) await callback();
-    },
-  };
-}
 
 export default function jahia(
   options: {
@@ -184,6 +174,10 @@ export default function jahia(
                       }
                     },
                   },
+                  // Only add the callback plugin in watch mode
+                  config.build?.watch &&
+                    options.watchCallback &&
+                    buildSuccessPlugin(options.watchCallback),
                 ],
               },
             },


### PR DESCRIPTION
### Description

Closes #490 

Now we try to run the callback at the end of each build. If another build is in progress, running the callback is skipped.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
