### PR TITLE
fix(create-module): add healthcheck to postgres

### DIFF
--- a/javascript-create-module/templates/module/docker-compose.yml
+++ b/javascript-create-module/templates/module/docker-compose.yml
@@ -2,7 +2,8 @@ services:
   jahia:
     image: jahia/jahia-ee:8.2
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     ports:
       - 8080:8080
       - 9229:9229
@@ -21,10 +22,15 @@ services:
       test: ["CMD", "curl", "http://localhost:8080/start"]
       interval: 5s
       timeout: 1s
-      retries: 24
+      retries: 30
 
   postgres:
     image: postgres:16
     environment:
       POSTGRES_USER: jahia
       POSTGRES_PASSWORD: dbpassword
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "jahia"]
+      interval: 5s
+      timeout: 1s
+      retries: 30


### PR DESCRIPTION
### Description

Fixes an issue reported by @kevinvandel: Jahia requires postgres pretty early in its startup sequence, and postgres might not be ready to accept requests

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
