### PR TITLE
fix(engine): make the virtual fs run on windows too

### DIFF
--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/JSFileSystem.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/JSFileSystem.java
@@ -70,9 +70,9 @@ public class JSFileSystem implements FileSystem {
    */
   @Override
   public void checkAccess(Path path, Set<? extends AccessMode> modes, LinkOption... linkOptions) throws IOException {
-    String resource = pathToResource(path);
-    if (!resource.startsWith(ROOT_JS_LIBS_DIR)) {
-      throw new IOException("Access refused to import " + resource);
+    String resourceName = pathToResourceName(path);
+    if (!resourceName.startsWith(ROOT_JS_LIBS_DIR)) {
+      throw new IOException("Access refused to import " + resourceName);
     }
   }
 
@@ -103,10 +103,10 @@ public class JSFileSystem implements FileSystem {
   @Override
   public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs)
       throws IOException {
-    String resource = pathToResource(path);
-    URL url = bundleContext.getBundle().getResource(resource);
+    String resourceName = pathToResourceName(path);
+    URL url = bundleContext.getBundle().getResource(resourceName);
     if (url == null) {
-      throw new FileNotFoundException("Cannot import " + resource + ", the file does not exist");
+      throw new FileNotFoundException("Cannot import " + resourceName + ", the file does not exist");
     }
 
     try (InputStream inputStream = url.openStream()) {
@@ -158,7 +158,7 @@ public class JSFileSystem implements FileSystem {
    * 1. Normalize (resolve . and ..)
    * 2. Convert system-specific separators into OSGi-compatible forward slashes
    */
-  private String pathToResource(Path path) {
+  private String pathToResourceName(Path path) {
     return path.normalize().toString().replace('\\', '/');
   }
 }


### PR DESCRIPTION
### Description

Closes #500 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)

---

## Testing

The only appears on bare metal setup (i.e. NOT Docker), because the Path class behaves differently when running Java directly on Windows.

0. (Be on Windows)
1. Install OpenJDK 17
2. Start Jahia in Windows with SDK or Enterprise Installer
3. Install JSM snapshot
4. Install latest [luxe](https://store.jahia.com/contents/modules-repository/org/jahia/modules/javascript/luxe-jahia-demo.html) and [luxe prepack](https://store.jahia.com/contents/modules-repository/org/jahia/modules/luxe-prepackaged-website.html)
5. Import the prepack
6. Open Luxe and see if it works


