### PR TITLE
fix: ensure internal graal imports are ignored on windows

### DIFF
--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/JSFileSystem.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/JSFileSystem.java
@@ -52,13 +52,15 @@ public class JSFileSystem implements FileSystem {
    *
    * For instance, it might receive
    * <code>/META-INF/js/libs/react-i18next.js</code> (stringified output of the
-   * method) or <code>/usr/local/graalvm/languages/js</code> (internal import).
+   * method) or <code>/usr/local/graalvm/languages/js</code> (internal import) or
+   * even worse <code>d:\jdk17\languages\js</code> on Windows.
+   *
    * This is safe-guarded by this <code>path.startsWith("/")</code> check until
    * someone comes with a better solution.
    */
   @Override
   public Path parsePath(String path) {
-    if (path.startsWith("/")) {
+    if (path.startsWith("/") || path.contains(":\\")) {
       return Path.of(path);
     }
 

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/JSFileSystem.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/JSFileSystem.java
@@ -60,7 +60,7 @@ public class JSFileSystem implements FileSystem {
    */
   @Override
   public Path parsePath(String path) {
-    if (path.startsWith("/") || path.startsWith("\\") || path.contains(":\\")) {
+    if (path.startsWith("/") || path.contains("\\")) {
       return Path.of(path);
     }
 

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/JSFileSystem.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/JSFileSystem.java
@@ -55,12 +55,12 @@ public class JSFileSystem implements FileSystem {
    * method) or <code>/usr/local/graalvm/languages/js</code> (internal import) or
    * even worse <code>d:\jdk17\languages\js</code> on Windows.
    *
-   * This is safe-guarded by this <code>path.startsWith("/")</code> check until
+   * This is safe-guarded by this <code>path.startsWith</code> check until
    * someone comes with a better solution.
    */
   @Override
   public Path parsePath(String path) {
-    if (path.startsWith("/") || path.contains(":\\")) {
+    if (path.startsWith("/") || path.startsWith("\\") || path.contains(":\\")) {
       return Path.of(path);
     }
 


### PR DESCRIPTION
### Description

Testing on Windows failed at a different yet unexpected step, see #500

Fix confirmed to be working by @x0h01 🎉


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
