### PR TITLE
ci: simplify provisioning files by removing hard-coded versions

### DIFF
--- a/javascript-modules-engine/tests/provisioning-manifest-snapshot.yml
+++ b/javascript-modules-engine/tests/provisioning-manifest-snapshot.yml
@@ -5,12 +5,12 @@
   uninstallPreviousVersion: true
 
 - installBundle:
-    - "js:mvn:org.jahia.test/javascript-modules-engine-test-module/0.9.0-SNAPSHOT/tgz"
+    - "js:mvn:org.jahia.test/javascript-modules-engine-test-module/LATEST/tgz"
   autoStart: true
   uninstallPreviousVersion: true
 
 - installBundle:
-    - "js:mvn:org.jahia.samples/javascript-modules-samples-hydrogen/0.9.0-SNAPSHOT/tgz"
+    - "js:mvn:org.jahia.samples/javascript-modules-samples-hydrogen/LATEST/tgz"
   autoStart: true
   uninstallPreviousVersion: true
 


### PR DESCRIPTION
### Description
Simplify provisioning files by replacing hard-coded versions by the Maven "metaversion" `LATEST`, that points to the latest version (including releases and snapshots).
The main benefit is that we won't need to update those files anymore when releasing (that bumps the version).

Run to validate the change: https://github.com/Jahia/javascript-modules/actions/runs/18312013907


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
