### PR TITLE
feat: support for custom module name

### DIFF
--- a/jahia-test-module/package.json
+++ b/jahia-test-module/package.json
@@ -34,6 +34,7 @@
     "yarn": ">=4.0.0"
   },
   "jahia": {
+    "name": "JS Modules Engine Test Module",
     "maven": {
       "groupId": "org.jahia.test",
       "distributionManagement": {

--- a/javascript-create-module/templates/hello-world/package.json
+++ b/javascript-create-module/templates/hello-world/package.json
@@ -48,6 +48,7 @@
     "node": ">=22.0.0"
   },
   "jahia": {
+    "name": "$MODULE",
     "snapshot": true,
     "module-dependencies": "default",
     "module-type": "templatesSet",

--- a/javascript-create-module/templates/module/package.json
+++ b/javascript-create-module/templates/module/package.json
@@ -42,6 +42,7 @@
     "node": ">=22.0.0"
   },
   "jahia": {
+    "name": "$MODULE",
     "snapshot": true,
     "module-dependencies": "default",
     "module-type": "module",

--- a/javascript-create-module/templates/template-set/package.json
+++ b/javascript-create-module/templates/template-set/package.json
@@ -45,6 +45,7 @@
     "node": ">=22.0.0"
   },
   "jahia": {
+    "name": "$MODULE",
     "snapshot": true,
     "module-dependencies": "default",
     "module-type": "templatesSet",

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jshandler/JavascriptProtocolConnection.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jshandler/JavascriptProtocolConnection.java
@@ -190,11 +190,10 @@ public class JavascriptProtocolConnection extends URLConnection {
         // First let's setup Bundle headers
         instructions.put("Bundle-Category", jahiaProps.getOrDefault("category", "jahia-javascript-module"));
         setIfPresent(properties, "description", instructions, "Bundle-Description");
-        String name = (String) properties.get("name");
+        String name = StringUtils.defaultString((String) jahiaProps.get("name"), (String) properties.get("name"));
         instructions.put("Bundle-Name", name + " (javascript module)");
-        instructions.put("Bundle-SymbolicName", name.replace("@", "")
-                .replace('/', '-')
-                .replaceAll("[^a-zA-Z0-9\\-\\.\\s]", "_"));
+        instructions.put("Bundle-SymbolicName",
+                ((String) properties.get("name")).replace("@", "").replace('/', '-').replaceAll("[^a-zA-Z0-9\\-\\.\\s]", "_"));
         setIfPresent(properties, "author", instructions, "Bundle-Vendor");
         instructions.put("Bundle-Version", getBundleVersion(properties, jahiaProps));
         instructions.put("Implementation-Version", getImplementationVersion(properties, jahiaProps));

--- a/javascript-modules-engine/tests/cypress/e2e/module/moduleTransformationTest.cy.ts
+++ b/javascript-modules-engine/tests/cypress/e2e/module/moduleTransformationTest.cy.ts
@@ -5,22 +5,28 @@ describe("Check that the Javascript module has been transformed properly and has
     }).then((result) => {
       console.log(result);
       expect(result).to.contain("Bundle-Category: jahia-javascript-module");
-      expect(result).to.contain("Bundle-Description: Test module for Javascript Module Engine");
+      expect(result).to.contain(
+        "Bundle-Description: Test module for Javascript Module Engine"
+      );
       expect(result).to.contain("Jahia-GroupId: org.jahia.test");
       expect(result).to.contain("Bundle-License: MIT");
       expect(result).to.contain(
-        "Bundle-Name: javascript-modules-engine-test-module (javascript module)",
+        "Bundle-Name: JS Modules Engine Test Module (javascript module)"
       );
-      expect(result).to.contain("Bundle-SymbolicName: javascript-modules-engine-test-module");
+      expect(result).to.contain(
+        "Bundle-SymbolicName: javascript-modules-engine-test-module"
+      );
       expect(result).to.contain("Bundle-Vendor: Jahia Solutions Group SA");
       expect(result).to.contain("Bundle-Version: ");
       // TODO to enable once javascript-modules-engine >= 0.4.0 is included in jahia-pack
       // expect(result).to.contain('Jahia-Depends: default,legacy-default-components,javascript-modules-engine')
       expect(result).to.contain("Jahia-Module-Type: templatesSet");
-      expect(result).to.contain("Jahia-javascript-InitScript: dist/server/index.js");
+      expect(result).to.contain(
+        "Jahia-javascript-InitScript: dist/server/index.js"
+      );
       expect(result).to.contain("Jahia-Required-Version: 8.2.0.0-SNAPSHOT");
       expect(result).to.contain(
-        "Jahia-Static-Resources: /css,/javascript,/icons,/dist/client,/static",
+        "Jahia-Static-Resources: /css,/javascript,/icons,/dist/client,/static"
       );
     });
   });


### PR DESCRIPTION
### Description
Instead of using the `name` field of the `package.json` as the module name (`Bundle-Name`), support for a custom `name` under the `jahia` section.
The `name` field is restricted, see https://docs.npmjs.com/creating-a-package-json-file:
> The "name" field contains your package's name and must be lowercase without any spaces. May contain hyphens, dots, and underscores.

When there is no such limitation on the custom Jahia one:
```json
{
  "name": "my-module",
  ...
  "jahia": {
    "name": "Any name I want",
    ...
  }
}

```

NB: the symbolic name (`Bundle-SymbolicName`) remains based on the `name` field (for consistency with the Maven modules that use `<artifactId>`).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
