### PR TITLE
fix(create-module): ensure compatibility with yarn create

### DIFF
--- a/javascript-create-module/package.json
+++ b/javascript-create-module/package.json
@@ -34,5 +34,6 @@
   },
   "engines": {
     "node": ">=22.0.0"
-  }
+  },
+  "preferUnplugged": true
 }


### PR DESCRIPTION
### Description

`yarn create @jahia/module` should work the same as `npm init @jahia/module@latest` but fails because of filesystem errors. [This flag](https://yarnpkg.com/configuration/manifest#preferUnplugged) enforces a physical filesystem (node_modules) instead of a virtual one (zipfs).

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
