### PR TITLE
build: Use JDK zip file if already existing locally

### DIFF
--- a/javascript-modules-engine-java/pom.xml
+++ b/javascript-modules-engine-java/pom.xml
@@ -215,7 +215,8 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${project.build.directory}/java-ts-bind/sources" />
-                                <get src="https://codeload.github.com/openjdk/jdk17u/zip/refs/heads/master" dest="${project.build.directory}/java-ts-bind/sources/jdk17u-master.zip" />
+                                <get src="https://codeload.github.com/openjdk/jdk17u/zip/refs/heads/master"
+                                     dest="${project.build.directory}/java-ts-bind/sources/jdk17u-master.zip" skipexisting="true"/>
                                 <unzip src="${project.build.directory}/java-ts-bind/sources/jdk17u-master.zip" dest="${project.build.directory}/java-ts-bind/sources">
                                     <patternset>
                                         <include name="jdk17u-master/src/java.base/share/classes/**" />


### PR DESCRIPTION
### Description
Do not re-download the JDK zip file (`jdk17u-master.zip`) if it already exists locally, to speed up local Maven build.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
