### PR TITLE
chore(deps): Bump commons-pool2 from 2.9.0 to 2.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-pool2</artifactId>
-                <version>2.9.0</version>
+                <version>2.12.1</version>
             </dependency>
             <dependency>
                 <groupId>io.github.bensku</groupId>


### PR DESCRIPTION
### Description
Bump [Apache Commons Pool](https://mvnrepository.com/artifact/org.apache.commons/commons-pool2) from 2.9.0 to 2.12.1 (latest as of today).
Note that this dependency is embedded in the _JavaScript Modules Engine_ module (not provided by Jahia).
> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
