### PR TITLE
fix(vite-plugin): Respect custom context in .env

### DIFF
--- a/vite-plugin/bin/jahia-deploy.js
+++ b/vite-plugin/bin/jahia-deploy.js
@@ -44,10 +44,10 @@ body.append(
 body.append("file", new File([fs.readFileSync("./dist/package.tgz")], "package.tgz"));
 
 // Send the payload to the Jahia provisioning API
-const jahiaHost = process.env.JAHIA_HOST || "http://localhost:8080";
-const baseUrl = jahiaHost.endsWith("/") ? jahiaHost : jahiaHost + "/";
-const provisioningUrl = new URL(`${baseUrl}modules/api/provisioning`);
-console.log(`Deploying the package to Jahia (${provisioningUrl.toString()})...`);
+const host = process.env.JAHIA_HOST || "http://localhost:8080";
+// use a relative path to the base URL that should end with a slash (to support custom context paths)
+const provisioningUrl = new URL("modules/api/provisioning", host.endsWith("/") ? host : `${host}/`);
+console.log(`Deploying the package to Jahia (${styleText("underline", "%s")})...`, provisioningUrl);
 const response = await fetch(provisioningUrl, {
   method: "POST",
   headers: {


### PR DESCRIPTION
Fixes https://github.com/Jahia/javascript-modules/issues/550.
### Description


Fix an issue in the vite-plugin where it is not possible to deploy a JavaScript module when using a custom context.

For instance, with the following `.env`:
```
JAHIA_USER=root:root1234
JAHIA_HOST=http://localhost:8081/custom-context
```


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
