### PR TITLE
ci: Use correct branch on merge to main

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -69,6 +69,7 @@ jobs:
       jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
       module_id: javascript-modules-engine
       testrail_project: Javascript Modules Engine
+      module_branch: ${{ github.ref }}
       provisioning_manifest: provisioning-manifest-build.yml
       artifact_prefix: js-eng
 


### PR DESCRIPTION
### Description

`reusable-integration-tests.yml` uses `master` as default branch.
So set it to `${{ github.ref }}` to use the correct branch (`main` in the current setup).
Should fix the _On merge to main_ workflow currently broken: https://github.com/Jahia/javascript-modules/actions/runs/19422103524


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
