### PR TITLE
feat: embed graalvm libs

### DIFF
--- a/javascript-modules-engine-java/pom.xml
+++ b/javascript-modules-engine-java/pom.xml
@@ -92,27 +92,7 @@
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>graal-sdk</artifactId>
-            <version>${graalvm.languages.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.truffle</groupId>
-            <artifactId>truffle-api</artifactId>
-            <version>${graalvm.languages.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.js</groupId>
-            <artifactId>js</artifactId>
-            <version>${graalvm.languages.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
-            <version>72.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.graalvm.regex</groupId>
-            <artifactId>regex</artifactId>
-            <version>${graalvm.languages.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jahia.server</groupId>
@@ -325,10 +305,6 @@
                                 <ignoredUnusedDeclaredDependency>org.apache.jackrabbit:jackrabbit-spi-commons</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.osgi:osgi.annotation</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.graalvm.truffle:truffle-api</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.graalvm.js:js</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.graalvm.regex:regex</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>com.ibm.icu:icu4j</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>xml-apis:xml-apis</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>

--- a/javascript-modules-engine/pom.xml
+++ b/javascript-modules-engine/pom.xml
@@ -32,6 +32,11 @@
         <jahia-module-signature>MCwCFF8pa94JvEWuLD2l0KT+RNNju5DRAhRc+JBdlQszeM1vze59Md6GmEAb5A==</jahia-module-signature>
         <require-capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version&gt;=17))"</require-capability>
         <yarn-build>build</yarn-build>
+        <Export-Package>
+            org.graalvm.*;version="${graalvm.version}",
+            com.oracle.truffle.*;version="${graalvm.version}",
+            com.oracle.js.*;version="${graalvm.version}"
+        </Export-Package>
     </properties>
 
     <dependencies>
@@ -44,6 +49,22 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>javascript-modules-engine-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.truffle</groupId>
+            <artifactId>truffle-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.regex</groupId>
+            <artifactId>regex</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,7 @@
         <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
         <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
         <!-- Graalvm libs -->
-        <graalvm.sdk.version>17.0.12</graalvm.sdk.version>
-        <graalvm.languages.version>23.0.5</graalvm.languages.version>
+        <graalvm.version>23.0.5</graalvm.version>
     </properties>
 
     <dependencyManagement>
@@ -106,6 +105,28 @@
                 <artifactId>vite-plugin</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
+            </dependency>
+
+            <!-- GraalVM dependencies: -->
+            <dependency>
+                <groupId>org.graalvm.sdk</groupId>
+                <artifactId>graal-sdk</artifactId>
+                <version>${graalvm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.graalvm.truffle</groupId>
+                <artifactId>truffle-api</artifactId>
+                <version>${graalvm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.graalvm.js</groupId>
+                <artifactId>js</artifactId>
+                <version>${graalvm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.graalvm.regex</groupId>
+                <artifactId>regex</artifactId>
+                <version>${graalvm.version}</version>
             </dependency>
 
             <!-- Jahia dependencies: -->
@@ -173,11 +194,6 @@
                 <groupId>org.apache.jackrabbit</groupId>
                 <artifactId>jackrabbit-spi-commons</artifactId>
                 <version>${jackrabbit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.graalvm.sdk</groupId>
-                <artifactId>graal-sdk</artifactId>
-                <version>${graalvm.languages.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jahia.server</groupId>


### PR DESCRIPTION
fixes https://github.com/Jahia/javascript-modules/issues/556
### Description
Embed graalvm libs with javascript module engine. 
Provided version are the same as the one in Jahia. 
```
        <graalvm.sdk.version>17.0.12</graalvm.sdk.version>
        <graalvm.languages.version>23.0.5</graalvm.languages.version>
```


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
