### PR TITLE
ci: run publication jobs on ubuntu-latest

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -83,7 +83,7 @@ jobs:
     name: Publish module
     needs: [integration-tests-standalone]
     if: github.ref == 'refs/heads/main'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-mvn-loaded
       credentials:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   on-release:
     if: ${{ github.event.release.prerelease == true }}
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     # The cimg-mvn-cache is an image containing a .m2 folder warmed-up
     # with common Jahia dependencies. Using this prevents maven from


### PR DESCRIPTION
### Description

self-hosted -> ubuntu-latest to enable npm provenance certificate

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
