### PR TITLE
chore: Remove GraalVM and 'js' extension checks

### DIFF
--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/GraalVMEngine.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/GraalVMEngine.java
@@ -23,7 +23,6 @@ import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.graalvm.home.Version;
 import org.graalvm.polyglot.*;
 import org.graalvm.polyglot.io.IOAccess;
 import org.graalvm.polyglot.proxy.ProxyObject;
@@ -105,7 +104,6 @@ public class GraalVMEngine {
         logger.debug("GraalVMEngine.activate");
         this.bundleContext = bundleContext;
 
-        initialEngineCheckup();
         try {
             initScripts.put(bundleContext.getBundle(),
                     getGraalSource(bundleContext.getBundle(), "META-INF/js/main.js"));
@@ -181,26 +179,6 @@ public class GraalVMEngine {
             logger.error("Cannot get resource: " + path, e);
         }
         return null;
-    }
-
-    private void initialEngineCheckup() {
-        // check VM
-        if (!Version.getCurrent().isRelease()) {
-            String specVersion = System.getProperty("java.specification.version", UNKNOWN_SYS_PROP);
-            String vendorVersion = System.getProperty("java.vendor.version", specVersion);
-            String vendor = System.getProperty("java.vendor", UNKNOWN_SYS_PROP);
-            logger.warn("Javascript Modules Engine requires GraalVM for production usage, detected {} (vendor: {}).",
-                    vendorVersion, vendor);
-            return;
-        }
-
-        // Check if the 'js' extension is installed
-        try (Context context = Context.create()) {
-            if (!context.getEngine().getLanguages().containsKey(JS)) {
-                logger.error(
-                        "Javascript Modules Engine detected GraalVM, but the 'js' extension is not installed. You can install it by running: gu install js");
-            }
-        }
     }
 
     private void initializePool(Map<String, String> poolOptions) {


### PR DESCRIPTION
Closes https://github.com/Jahia/javascript-modules/issues/608.
### Description

Remove the checks and warning logs related to GraalVM and the 'js' language extension from the JavaScript Modules Engine initialization code.

### Why were these checks removed?
- **GraalVM Check:** The code previously warned if GraalVM was not detected, but this is no longer relevant as we've decided to only use OpenJDK (in our Docker images).
- **'js' Extension Check:** The 'js' extension is specific to GraalVM and enables JavaScript execution within the JVM. Since OpenJDK does not support GraalVM language extensions, this check is obsolete and has been removed.

### Impact
- The engine initialization is now cleaner and does not log unnecessary warnings when running on OpenJDK.
- There is no equivalent check for JavaScript engine support in OpenJDK, as it does not provide GraalVM's polyglot features.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
