### PR TITLE
fix(library): relax jahiaComponent return type

### DIFF
--- a/javascript-modules-library/src/framework/jahiaComponent.tsx
+++ b/javascript-modules-library/src/framework/jahiaComponent.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "react";
+import type { ReactNode } from "react";
 import { type ServerContext, useServerContext } from "../hooks/useServerContext.js";
 import { getNodeProps } from "../utils/jcr/getNodeProps.js";
 
@@ -43,7 +43,7 @@ export interface JahiaComponent {
  * @param definitions The definitions of the component
  * @param Component The component to register
  */
-export const jahiaComponent = <T extends (props: never, context: ServerContext) => JSX.Element>(
+export const jahiaComponent = <T extends (props: never, context: ServerContext) => ReactNode>(
   { id, ...definitions }: JahiaComponent,
   Component: T,
 ): T => {
@@ -68,7 +68,7 @@ export const jahiaComponent = <T extends (props: never, context: ServerContext) 
 };
 
 /** Wraps `Component` to retrieve props from the JCR layer and pass them as usual component props. */
-const wrap = (Component: (props: never, context: ServerContext) => JSX.Element) => () => {
+const wrap = (Component: (props: never, context: ServerContext) => ReactNode) => () => {
   // Retrieve the current context
   const context = useServerContext();
 


### PR DESCRIPTION
### Description

> Represents all of the things React can render.
> Where ReactElement only represents JSX, ReactNode represents everything that can be rendered.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
