### PR TITLE
chore(renovate): Add min release age for NPM updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,9 @@
   "major": {
     "dependencyDashboardApproval": true
   },
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
   "minor": {
     "dependencyDashboardApproval": true
   },


### PR DESCRIPTION
### Description

Wait for at least 3 days before opening a PR for a dependency update.
See https://docs.renovatebot.com/key-concepts/minimum-release-age/ for details.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
