### PR TITLE
chore: remove warning about JDK not supporting runtime compilation

### DIFF
--- a/javascript-modules-engine/src/main/resources/META-INF/configurations/org.jahia.modules.javascript.modules.engine.jsengine.GraalVMEngine.cfg
+++ b/javascript-modules-engine/src/main/resources/META-INF/configurations/org.jahia.modules.javascript.modules.engine.jsengine.GraalVMEngine.cfg
@@ -32,3 +32,6 @@ pool.maxIdle=100
 # experimental=true
 # polyglot.js.performance=true
 # polyglot.cpusampler=true
+# Remove the warning that the implementation does not support runtime compilation
+# See https://www.graalvm.org/latest/reference-manual/js/FAQ/#warning-implementation-does-not-support-runtime-compilation
+polyglot.engine.WarnInterpreterOnly=false


### PR DESCRIPTION
### Description
Remove the warning stating that the JDK does not support runtime compilation:
```
[engine] WARNING: The polyglot context is using an implementation that does not support runtime compilation.
The guest application code will therefore be executed in interpreted mode only.
Execution only in interpreted mode will strongly impair guest application performance.
To disable this warning, use the '--engine.WarnInterpreterOnly=false' option or the '-Dpolyglot.engine.WarnInterpreterOnly=false' system property.
```

This message appears currently each time a JS module is deployed.

This could/should have been addressed as part of https://github.com/Jahia/javascript-modules/issues/608 (migration from GraalVM to OpenJDK) but got missed.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
