### PR TITLE
fix(create-module): add missing namespaces

### DIFF
--- a/javascript-create-module/templates/module/settings/definitions.cnd
+++ b/javascript-create-module/templates/module/settings/definitions.cnd
@@ -1,5 +1,11 @@
+<nt = 'http://www.jcp.org/jcr/nt/1.0'>
+<mix = 'http://www.jcp.org/jcr/mix/1.0'>
+<jcr = 'http://www.jcp.org/jcr/1.0'>
+<j = 'http://www.jahia.org/jahia/1.0'>
 <jnt = 'http://www.jahia.org/jahia/nt/1.0'>
 <jmix = 'http://www.jahia.org/jahia/mix/1.0'>
+
+// Module specific namespaces
 <$NAMESPACE = 'https://example.com/$MODULE/nt/1.0'>
 <$NAMESPACEmix = 'https://example.com/$MODULE/mix/1.0'>
 


### PR DESCRIPTION
### Description

Add common JCR namespaces to the create-module/archetype

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
