### PR TITLE
ci: Prevent CI workflow to be triggered during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
                             <includes>
                                 javascript-modules-engine/yarn.lock,jahia-test-module/yarn.lock
                             </includes>
-                            <!-- import to use "skip ci" to prevent the "on merge to main" workflow to be triggered halfway during the release process -->
+                            <!-- important to use "skip ci" to prevent the "on merge to main" workflow to be triggered halfway during the release process -->
                             <message>chore(release): Prepare release ${project.version} [skip ci]</message>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
### Description

When bumping the `version` field in the `package.json` as part of the release process, use `[skip ci]` in the commit message to ensure there is no workflow triggered when that commit is pushed to main.
Similar to https://github.com/Jahia/user-password-authentication/pull/136.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
