### PR TITLE
chore(scaffold): Explicitly set minimum required Jahia version

### DIFF
--- a/javascript-create-module/templates/hello-world/package.json
+++ b/javascript-create-module/templates/hello-world/package.json
@@ -49,6 +49,7 @@
   },
   "jahia": {
     "name": "$MODULE",
+    "required-version": "8.2.1.0",
     "snapshot": true,
     "module-dependencies": "default",
     "module-type": "templatesSet",

--- a/javascript-create-module/templates/module/package.json
+++ b/javascript-create-module/templates/module/package.json
@@ -43,6 +43,7 @@
   },
   "jahia": {
     "name": "$MODULE",
+    "required-version": "8.2.1.0",
     "snapshot": true,
     "module-dependencies": "default",
     "module-type": "module",

--- a/javascript-create-module/templates/template-set/package.json
+++ b/javascript-create-module/templates/template-set/package.json
@@ -46,6 +46,7 @@
   },
   "jahia": {
     "name": "$MODULE",
+    "required-version": "8.2.1.0",
     "snapshot": true,
     "module-dependencies": "default",
     "module-type": "templatesSet",


### PR DESCRIPTION
Relates to https://github.com/Jahia/user-password-authentication/pull/140.
### Description
When generating the skeleton of a JavaScript Module project with https://www.npmjs.com/package/@jahia/create-module, define the mininum Jahia version required (`required-version` field) in the `package.json`.
This way, the version is explicit instead of relying on the default value (see https://github.com/Jahia/javascript-modules/blob/main/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jshandler/JavascriptProtocolConnection.java#L242).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
