### PR TITLE
fix: wait for the configuration to activate GraalVMEngine

### DIFF
--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/GraalVMEngine.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/jsengine/GraalVMEngine.java
@@ -53,7 +53,7 @@ import static org.jahia.modules.javascript.modules.engine.jshandler.JavascriptPr
 /**
  * Base JS engine based on GraalVM
  */
-@Component(service = GraalVMEngine.class, immediate = true)
+@Component(service = GraalVMEngine.class, immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class GraalVMEngine {
     private static final Logger logger = LoggerFactory.getLogger(GraalVMEngine.class);
 
@@ -101,7 +101,7 @@ public class GraalVMEngine {
 
     @Activate
     public void activate(BundleContext bundleContext, Map<String, ?> props) {
-        logger.debug("GraalVMEngine.activate");
+        logger.info("Registering GraalVMEngine");
         this.bundleContext = bundleContext;
 
         try {
@@ -126,6 +126,7 @@ public class GraalVMEngine {
         }
         sharedEngine = builder.build();
         initializePool(poolOptions);
+        logger.info("Registered GraalVMEngine");
     }
 
     @Deactivate
@@ -134,6 +135,7 @@ public class GraalVMEngine {
         pool.close();
         sharedEngine.close(true);
         currentContext.remove();
+        logger.info("Unregistered GraalVMEngine");
     }
 
     public <T> T doWithContext(Function<ContextProvider, T> callback) {

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/registrars/ViewsRegistrar.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/registrars/ViewsRegistrar.java
@@ -30,6 +30,8 @@ import org.jahia.services.templates.JahiaTemplateManagerService;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
@@ -39,6 +41,8 @@ import java.util.stream.Collectors;
 
 @Component(immediate = true, service = {ViewsRegistrar.class, Registrar.class, ScriptResolver.class, JahiaEventListener.class})
 public class ViewsRegistrar implements ScriptResolver, TemplateResolver, Registrar, JahiaEventListener<EventObject> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ViewsRegistrar.class);
 
     private static final Class<EventObject>[] ACCEPTED_EVENT_TYPES = new Class[] {
             JahiaTemplateManagerService.TemplatePackageRedeployedEvent.class,
@@ -65,6 +69,7 @@ public class ViewsRegistrar implements ScriptResolver, TemplateResolver, Registr
 
     @Activate
     public void activate(BundleContext context) {
+        logger.info("Registering ViewsRegistrar");
         List<ScriptResolver> scriptResolvers = new ArrayList<>(renderService.getScriptResolvers());
         scriptResolvers.add(0, this);
         renderService.setScriptResolvers(scriptResolvers);
@@ -72,6 +77,7 @@ public class ViewsRegistrar implements ScriptResolver, TemplateResolver, Registr
         List<TemplateResolver> templateResolvers = new ArrayList<>(renderService.getTemplateResolvers());
         templateResolvers.add(0, this);
         renderService.setTemplateResolvers(templateResolvers);
+        logger.info("Registered ViewsRegistrar");
     }
 
     @Deactivate
@@ -83,6 +89,7 @@ public class ViewsRegistrar implements ScriptResolver, TemplateResolver, Registr
         List<TemplateResolver> templateResolvers = new ArrayList<>(renderService.getTemplateResolvers());
         templateResolvers.remove(this);
         renderService.setTemplateResolvers(templateResolvers);
+        logger.info("Unregistered ViewsRegistrar");
     }
     @Override
     public void register(Bundle bundle) {


### PR DESCRIPTION
Fixes https://github.com/Jahia/jahia-private/issues/4126

### Description
Attempt to fix the following error:
```
2026-01-19 01:44:18,678: ERROR [Framework] - FrameworkEvent ERROR
org.osgi.framework.ServiceException: Service factory returned null. (Component: org.jahia.modules.javascript.modules.engine.registrars.ViewsRegistrar (80))
	... suppressed 40 lines
	at org.osgi.util.tracker.BundleTracker$Tracked.customizerModified(BundleTracker.java:488) ~[org.apache.felix.framework-6.0.5.jar:?]
	at org.osgi.util.tracker.BundleTracker$Tracked.customizerModified(BundleTracker.java:420) ~[org.apache.felix.framework-6.0.5.jar:?]
	at org.osgi.util.tracker.AbstractTracked.track(AbstractTracked.java:232) ~[org.apache.felix.framework-6.0.5.jar:?]
	at org.osgi.util.tracker.BundleTracker$Tracked.bundleChanged(BundleTracker.java:450) ~[org.apache.felix.framework-6.0.5.jar:?]
	... suppressed 7 lines
	at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
```

This issue happens because at the time the `ViewsRegistrar` is read by one of its consumer, it has been removed from the OSGi service registry.
One culprit could be the configuration that operates a refresh of `ViewsRegistrar` dependency if detected after the service started, unregistering the service while being read by another process. 

Logs have been added to identify the source of the error in case it happen again.

the log are useful information that can remain even if the issue won't appear. 
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
