### PR TITLE
fix: Use useTranslation() hook server-side for proper i18n SSR

### DIFF
--- a/javascript-create-module/templates/hello-world/src/components/Hello/World/default.server.tsx
+++ b/javascript-create-module/templates/hello-world/src/components/Hello/World/default.server.tsx
@@ -4,8 +4,7 @@ import {
   buildModuleFileUrl,
   jahiaComponent,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
-import { Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import down from "./arrows/down.svg";
 import left from "./arrows/left.svg";
 import Celebrate from "./Celebrate.client.jsx";
@@ -20,48 +19,54 @@ jahiaComponent(
     componentType: "view",
     nodeType: "$NAMESPACE:helloWorld",
   },
-  ({ name }: Props, { renderContext }) => (
-    <section className={classes.section}>
-      <header className={classes.header}>
-        <h2>
+  ({ name }: Props, { renderContext }) => {
+    // IMPORTANT: Always use useTranslation() (not { t } from "i18next") in React components.
+    // This ensures translations are context-aware, update on language/namespace changes,
+    // and avoid hydration mismatches between server and client.
+    const { t } = useTranslation();
+    return (
+      <section className={classes.section}>
+        <header className={classes.header}>
+          <h2>
+            <Trans
+              i18nKey="Mbvdf2LrCB5sW9PUFXO48"
+              values={{ name }}
+              components={{ mark: <mark /> }}
+            />
+          </h2>
+          {renderContext.isEditMode() && (
+            <div className={classes.hint} style={{ alignItems: "center" }}>
+              <img src={buildModuleFileUrl(left)} alt="←" width="80" height="16" />
+              {t("0U2mp51dWjqWXje4x-eUV")}
+            </div>
+          )}
+        </header>
+        <p>{t("7l9zetMbU4cKpL4NxSOtL")}</p>
+        <div className={classes.grid}>
+          <RenderChildren />
+        </div>
+
+        <p className={classes.attribution}>
           <Trans
-            i18nKey="Mbvdf2LrCB5sW9PUFXO48"
-            values={{ name }}
-            components={{ mark: <mark /> }}
+            i18nKey="8S0DVCRSnmQRKF9lZnNGj"
+            components={{ a: <a href="https://undraw.co/" /> }}
           />
-        </h2>
+        </p>
+        <p>{t("OfBsezopuIko8aJ6X3kpw")}</p>
+        <Island component={Celebrate} />
+        <p>
+          <Trans
+            i18nKey="nr31fYHB-RqO06BCl4rYO"
+            components={{ a: <a href="https://jasonformat.com/islands-architecture/" /> }}
+          />
+        </p>
         {renderContext.isEditMode() && (
-          <div className={classes.hint} style={{ alignItems: "center" }}>
-            <img src={buildModuleFileUrl(left)} alt="←" width="80" height="16" />
-            {t("0U2mp51dWjqWXje4x-eUV")}
+          <div className={classes.hint} style={{ marginLeft: "calc(50% - 0.5rem)" }}>
+            <img src={buildModuleFileUrl(down)} alt="↓" width="70" height="100" />
+            {t("89D3xFLMZmCAencaqw68C")}
           </div>
         )}
-      </header>
-      <p>{t("7l9zetMbU4cKpL4NxSOtL")}</p>
-      <div className={classes.grid}>
-        <RenderChildren />
-      </div>
-
-      <p className={classes.attribution}>
-        <Trans
-          i18nKey="8S0DVCRSnmQRKF9lZnNGj"
-          components={{ a: <a href="https://undraw.co/" /> }}
-        />
-      </p>
-      <p>{t("OfBsezopuIko8aJ6X3kpw")}</p>
-      <Island component={Celebrate} />
-      <p>
-        <Trans
-          i18nKey="nr31fYHB-RqO06BCl4rYO"
-          components={{ a: <a href="https://jasonformat.com/islands-architecture/" /> }}
-        />
-      </p>
-      {renderContext.isEditMode() && (
-        <div className={classes.hint} style={{ marginLeft: "calc(50% - 0.5rem)" }}>
-          <img src={buildModuleFileUrl(down)} alt="↓" width="70" height="100" />
-          {t("89D3xFLMZmCAencaqw68C")}
-        </div>
-      )}
-    </section>
-  ),
+      </section>
+    );
+  },
 );

--- a/javascript-modules-engine/src/server/init-react.tsx
+++ b/javascript-modules-engine/src/server/init-react.tsx
@@ -22,8 +22,8 @@ server.registry.add("viewRenderer", "react", {
     const language = currentResource.getLocale().getLanguage();
     i18n.loadNamespaces(bundleKey);
     i18n.loadLanguages(language);
-    // Set module namespace and current language
-    i18n.setDefaultNamespace(bundleKey);
+    // Not safe if multiple components use different languages on the same page.
+    // But assumes a single language per page, so i18n.changeLanguage(lang) is safe in this context.
     i18n.changeLanguage(language);
 
     // SSR
@@ -39,7 +39,7 @@ server.registry.add("viewRenderer", "react", {
         jcrSession={currentNode.getSession()}
         bundleKey={bundleKey}
       >
-        <I18nextProvider i18n={i18n}>
+        <I18nextProvider i18n={i18n} defaultNS={bundleKey}>
           <View />
         </I18nextProvider>
       </ServerContextProvider>

--- a/javascript-modules-library/src/components/render/Island.tsx
+++ b/javascript-modules-library/src/components/render/Island.tsx
@@ -62,7 +62,7 @@ export function Island<Props>(
         }
       : "children" extends keyof Props
         ? // If the component has optional children, it may be client-only or not
-          | {
+            | {
                 // In SSR mode, the children are passed to the component and must be of the correct type
                 /**
                  * If false or undefined, the component will be rendered on the server. If true,
@@ -83,7 +83,7 @@ export function Island<Props>(
                 children?: ReactNode;
               }
         : // If the component has no children, it may be client-only or not
-          | {
+            | {
                 // In SSR mode, the component cannot have children
                 /**
                  * If false or undefined, the component will be rendered on the server. If true,
@@ -205,7 +205,7 @@ export function Island({
             clientOnly ? (
               children
             ) : (
-              <I18nextProvider i18n={i18n}>
+              <I18nextProvider i18n={i18n} defaultNS={bundleKey}>
                 <Component
                   {...props}
                   children={createElement("jsm-children", {

--- a/samples/hydrogen/src/components/HelloWorld/default.server.tsx
+++ b/samples/hydrogen/src/components/HelloWorld/default.server.tsx
@@ -1,11 +1,10 @@
 import {
-  Island,
-  RenderChildren,
   buildModuleFileUrl,
+  Island,
   jahiaComponent,
+  RenderChildren,
 } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
-import { Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import Celebrate from "./Celebrate.client.jsx";
 import classes from "./component.module.css";
 
@@ -16,6 +15,10 @@ jahiaComponent(
     componentType: "view",
   },
   ({ name }: { name: string }, { renderContext }) => {
+    // IMPORTANT: Always use useTranslation() (not { t } from "i18next") in React components.
+    // This ensures translations are context-aware, update on language/namespace changes,
+    // and avoid hydration mismatches between server and client.
+    const { t } = useTranslation();
     return (
       <>
         <section className={classes.section}>

--- a/samples/hydrogen/src/components/LanguageSwitcher/default.server.tsx
+++ b/samples/hydrogen/src/components/LanguageSwitcher/default.server.tsx
@@ -1,7 +1,7 @@
 import { buildNodeUrl, getSiteLocales, jahiaComponent } from "@jahia/javascript-modules-library";
-import { t } from "i18next";
 import { Fragment } from "react";
 import classes from "./component.module.css";
+import { useTranslation } from "react-i18next";
 
 jahiaComponent(
   {
@@ -12,6 +12,10 @@ jahiaComponent(
     properties: { "cache.timeout": "0" },
   },
   (_, { mainNode, currentResource }) => {
+    // IMPORTANT: Always use useTranslation() (not { t } from "i18next") in React components.
+    // This ensures translations are context-aware, update on language/namespace changes,
+    // and avoid hydration mismatches between server and client.
+    const { t } = useTranslation();
     const currentLanguage = currentResource.getLocale().toString();
     return (
       <p style={{ textAlign: "center" }}>


### PR DESCRIPTION
Fixes https://github.com/Jahia/javascript-modules/issues/317.
### Description
Use `useTranslation()` hook in server components: Replaced direct `import { t } from "i18next"` with usage of `useTranslation()` hook in all React server components (`HelloWorld`, `LanguageSwitcher`, etc.). This ensures translations are context-aware and avoid hydration mismatches between server and client.

Also, explicitly set the default namespace (`defaultNS`) in `I18nextProvider` wrapper to ensure proper translation loading for multiple modules on the same page. Its value is the bundle key (symbolic name).

### Testing

Enhance the existing Cypress test  with components from multiple JS modules on the same page, to validate:
- 2 components from `hydrogen` module render server-side translations
- 2 components from `javascript-modules-engine-test-module` render server-side translations
- All client-side translations hydrate and update correctly

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
