### PR TITLE
test(hydrogen): Only check the Hero CTA exists

### DIFF
--- a/tests/cypress/e2e/hydrogen-tutorial/3-about-us-page.cy.ts
+++ b/tests/cypress/e2e/hydrogen-tutorial/3-about-us-page.cy.ts
@@ -6,7 +6,7 @@ describe('Validate the concepts of the tutorial: 3 - The "About Us" Page', () =>
     // on the home page, a new CTA can be added
     cy.visit(`/jahia/jcontent/${HYDROGEN_SITE_KEY}/en/pages/home`);
     cy.iframe("#page-builder-frame-1").within(() => {
-      cy.get('button[data-sel-role="hydrogen:heroCallToAction"]').should("be.visible");
+      cy.get('button[data-sel-role="hydrogen:heroCallToAction"]').should("exist");
     });
     // but can't be added on the about-us page
     cy.visit(`/jahia/jcontent/${HYDROGEN_SITE_KEY}/en/pages/about-us`);


### PR DESCRIPTION
Fixes https://github.com/Jahia/javascript-modules/issues/670.
### Description
Looks like the CTA button is no longer visible when the page gets rendered, maybe following [this recent change](https://github.com/Jahia/jcontent/pull/2352)?

As we only test if the CTA button exists or not depending on the page, this PR replaces `.should("be.visible")` by `.should("exist")`.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
