### PR TITLE
fix: Make 'readOnly=children' areas editable in their own parent page

### DIFF
--- a/.chachalog/RFsycdD5.md
+++ b/.chachalog/RFsycdD5.md
@@ -1,0 +1,5 @@
+---
+javascript-modules: minor
+---
+
+Fixed absolute areas with readOnly="children" so they can be edited on their owning page. (#679)

--- a/jahia-test-module/src/react/server/views/testAbsoluteAreas/TestAbsoluteAreas.tsx
+++ b/jahia-test-module/src/react/server/views/testAbsoluteAreas/TestAbsoluteAreas.tsx
@@ -77,6 +77,15 @@ jahiaComponent(
         <AbsoluteArea name="pagecontent" parent={currentNode} readOnly="children" />
       </div>
 
+      <h2>Limited absolute area editing (home page parent)</h2>
+      <div data-testid="limitedAbsoluteAreaEditHomeParent">
+        <AbsoluteArea
+          name="limitedEditHomeArea"
+          parent={renderContext.getSite().getHome()}
+          readOnly="children"
+        />
+      </div>
+
       <h2>Absolute Area parameters</h2>
       <div data-testid="absoluteAreaParameters">
         <AbsoluteArea

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelper.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelper.java
@@ -403,6 +403,14 @@ public class RenderHelper {
         JCRNodeWrapper parent = readMandatoryAttribute(attr, "parent");
         String relativePath = calculateRelativePath(renderContext.getSite().getPath(), parent.getPath());
         attr.put("path", relativePath + "/" + name);
+
+        // internalRenderArea always pins "level" to the site root and conflicts with limitedAbsoluteAreaEdit for editing access.
+        // To keep compatibility, we compute the logic here instead against the real parent node.
+        if (Boolean.TRUE.equals(attr.get("limitedAbsoluteAreaEdit"))) {
+            boolean onOwnerPage = parent.getPath().equals(renderContext.getMainResource().getNodePath());
+            attr.put("limitedAbsoluteAreaEdit", !onOwnerPage);
+        }
+
         return internalRenderArea(attr, "absoluteArea", renderContext);
     }
 

--- a/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
+++ b/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
@@ -195,6 +195,7 @@ describe("Absolute Area test", () => {
   it(`${pageName}: Limited absolute area editing (home parent) is read-only on other pages`, () => {
     cy.iframe("#page-builder-frame-1").within(() => {
       cy.get('div[data-testid="limitedAbsoluteAreaEditHomeParent"]')
+        .should("contain", "Home limited edit area content")
         .find('div[type="existingNode"]')
         .should("not.exist");
     });
@@ -204,6 +205,7 @@ describe("Absolute Area test", () => {
     cy.visit(`/jahia/jcontent/${GENERIC_SITE_KEY}/en/pages/home`);
     cy.iframe("#page-builder-frame-1").within(() => {
       cy.get('div[data-testid="limitedAbsoluteAreaEditHomeParent"]')
+        .should("contain", "Home limited edit area content")
         .find('div[type="existingNode"]')
         .should("exist");
     });

--- a/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
+++ b/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
@@ -68,6 +68,31 @@ describe("Absolute Area test", () => {
     addSimplePage(`/sites/${GENERIC_SITE_KEY}`, "custom", "Custom", "en", "simple").then(() =>
       addSimplePage(`/sites/${GENERIC_SITE_KEY}/custom`, "sub-level", "Sub level", "en", "simple"),
     );
+
+    // Content for the absolute area whose parent is the home page itself, used to verify it's
+    // editable when rendered on the home page, and read-only when rendered on any other page.
+    addNode({
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home`,
+      name: "limitedEditHomeArea",
+      primaryNodeType: "jnt:contentList",
+    });
+    addNode({
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/limitedEditHomeArea`,
+      name: "bigText",
+      primaryNodeType: "jnt:bigText",
+      properties: [{ name: "text", value: "Home limited edit area content", language: "en" }],
+    });
+    // Renders TestAbsoluteAreas directly on the home page, so its main resource is the home page.
+    addNode({
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/pagecontent`,
+      name: "testOnHomePage",
+      primaryNodeType: "javascriptExample:testAbsoluteAreas",
+    });
+    addNode({
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/pagecontent/testOnHomePage`,
+      name: "basicArea",
+      primaryNodeType: "jnt:contentList",
+    });
   });
 
   beforeEach("Login and visit test page", () => {
@@ -164,6 +189,23 @@ describe("Absolute Area test", () => {
       cy.get('div[data-testid="limitedAbsoluteAreaEdit"]')
         .find('div[type="existingNode"]')
         .should("not.exist");
+    });
+  });
+
+  it(`${pageName}: Limited absolute area editing (home parent) is read-only on other pages`, () => {
+    cy.iframe("#page-builder-frame-1").within(() => {
+      cy.get('div[data-testid="limitedAbsoluteAreaEditHomeParent"]')
+        .find('div[type="existingNode"]')
+        .should("not.exist");
+    });
+  });
+
+  it("home: Limited absolute area editing (home parent) is editable on the home page", () => {
+    cy.visit(`/jahia/jcontent/${GENERIC_SITE_KEY}/en/pages/home`);
+    cy.iframe("#page-builder-frame-1").within(() => {
+      cy.get('div[data-testid="limitedAbsoluteAreaEditHomeParent"]')
+        .find('div[type="existingNode"]')
+        .should("exist");
     });
   });
 


### PR DESCRIPTION
### Description

**Issue**

Setting `readOnly="children"` parameter when rendering `<AbsoluteArea>` component makes the component read-only everywhere, including the owning (i.e. parent) page.

**Root cause** 

`RenderHelper.internalRenderArea()` ([link](https://github.com/Jahia/javascript-modules/blob/main/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/RenderHelper.java#L449)) pins `level = -1` before rendering taglib `AreaTag`. It looks like this was done so that `path` resolves relative to the site root for an arbitrary caller-supplied `parent`. But as a side effect, `AreaTag`'s check for owning page always resolves to the site root instead of the real `parent`/home page. This makes the  `limitedAbsoluteAreaEdit` [check](https://github.com/Jahia/jahia-private/blob/main/taglib/src/main/java/org/jahia/taglibs/template/include/AreaTag.java#L330) always set to read only.

**Fix** 

Added logic in `RenderHelper.renderAbsoluteArea` to resolve "is the current page the area's owner" check itself by setting appropriate `limitedAbsoluteAreaEdit` depending on whether current page is the owning page. `AreaTag` restricts editing (`limitedAbsoluteAreaEdit=true`) when the current page is *not* the owner. This leaves the `level = -1` / path-resolution mechanism untouched (still required for arbitrary `parent` support).

**Changes**
- `RenderHelper.java`: added `isMainResourceTheAreaParent` and used it in `renderAbsoluteArea` to resolve `limitedAbsoluteAreaEdit`.

**Tests**
- `TestAbsoluteAreas.tsx` / `absoluteAreaTest.cy.ts`: new fixture and Cypress assertions to test area is editable on its owning (home) page and stays read-only when rendered on any other page.

### Checklist
#### Source code
- [x] I've shared and documented any breaking change — N/A, no breaking change
- [x] I've reviewed and updated the jahia-depends — N/A, no dependency changes

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)