### PR TITLE
fix: Make sure graphql subrequests are handled correctly

### DIFF
--- a/.chachalog/BcOA3_X-.md
+++ b/.chachalog/BcOA3_X-.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+javascript-modules: minor
+---
+
+Make sure graphql subrequests are handled correctly (#681)

--- a/.chachalog/BcOA3_X-.md
+++ b/.chachalog/BcOA3_X-.md
@@ -1,6 +1,6 @@
 ---
 # Allowed version bumps: patch, minor, major
-javascript-modules: minor
+javascript-modules: patch
 ---
 
 Make sure graphql subrequests are handled correctly (#681)

--- a/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/gql/GQLHelper.java
+++ b/javascript-modules-engine-java/src/main/java/org/jahia/modules/javascript/modules/engine/js/server/gql/GQLHelper.java
@@ -93,6 +93,21 @@ public class GQLHelper {
         RenderContext renderContext = (RenderContext) parameters.get("renderContext");
         HttpServletRequest request = renderContext == null ? new HttpServletRequestMock(params)
                 : new HttpServletRequestWrapper(renderContext.getRequest()) {
+                    // This is a synthetic sub-request: the query/operationName/variables are supplied
+                    // through parameters, not through a body. The GraphQL servlet dispatches on the HTTP
+                    // method, and only the GET parser reads the query from parameters (the POST parser
+                    // reads the request body, which here is null or already consumed by the outer request,
+                    // e.g. a jContent preview "previewQueryByWorkspace" POST). We therefore force GET so the
+                    // parameter overrides below are honored regardless of how the outer request was made.
+                    // This also matches HttpServletRequestMock, which always reports GET.
+                    public String getMethod() {
+                        return "GET";
+                    }
+
+                    public String getContentType() {
+                        return null;
+                    }
+
                     public String getParameter(String name) {
                         if (params.containsKey(name)) {
                             return params.get(name);

--- a/tests/cypress/e2e/ui/gqlTest.cy.ts
+++ b/tests/cypress/e2e/ui/gqlTest.cy.ts
@@ -50,4 +50,38 @@ describe("Test GQL", () => {
       "Hello this is a sample rich text",
     );
   });
+
+  // Regression test for the POST render path (e.g. jContent preview's "previewQueryByWorkspace"):
+  // when a view using useGQLQuery is rendered while resolving "renderedContent" inside a GraphQL
+  // POST, the nested query used to fail with "No valid query found in request" / "Unexpected end of
+  // JSON input" because GQLHelper reused the incoming POST request and the servlet read the query
+  // from the (already consumed) body instead of the parameters. The GET render path above never hit
+  // this. See GQLHelper (forces GET on the synthetic sub-request).
+  it("Check GQL execution when the view is rendered inside a GraphQL POST request", function () {
+    cy.apollo({
+      variables: {
+        // Render the testGQL content node directly (its TestGQL view is registered as "default"),
+        // so we exercise the view's nested useGQLQuery without depending on a page template.
+        path: `/sites/${GENERIC_SITE_KEY}/home/testJGQL/pagecontent/test`,
+        templateType: "html",
+        view: "default",
+        contextConfiguration: "module",
+        language: "en",
+        workspace: "EDIT",
+      },
+      queryFile: "graphql/renderedContentByPath.graphql",
+    }).then((response: { data?: any; errors?: unknown[] }) => {
+      // Before the fix the nested useGQLQuery threw, surfacing as a GraphQL error and null output.
+      expect(response.errors, "GraphQL errors").to.satisfy(
+        (errors: unknown[] | undefined) => errors == null || errors.length === 0,
+      );
+      const output = response.data?.jcr?.nodeByPath?.renderedContent?.output as string;
+      expect(output, "rendered output").to.be.a("string").and.not.be.empty;
+      // These values are produced by the nested useGQLQuery call inside the TestGQL view, so their
+      // presence proves the re-entrant GraphQL query resolved during the POST render.
+      expect(output).to.contain("prop1 value");
+      expect(output).to.contain("prop2 value !@#$%ˆ//{}È");
+      expect(output).to.contain("test component");
+    });
+  });
 });

--- a/tests/cypress/e2e/ui/gqlTest.cy.ts
+++ b/tests/cypress/e2e/ui/gqlTest.cy.ts
@@ -70,6 +70,7 @@ describe("Test GQL", () => {
         workspace: "EDIT",
       },
       queryFile: "graphql/renderedContentByPath.graphql",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }).then((response: { data?: any; errors?: unknown[] }) => {
       // Before the fix the nested useGQLQuery threw, surfacing as a GraphQL error and null output.
       expect(response.errors, "GraphQL errors").to.satisfy(

--- a/tests/cypress/fixtures/graphql/renderedContentByPath.graphql
+++ b/tests/cypress/fixtures/graphql/renderedContentByPath.graphql
@@ -1,0 +1,21 @@
+query (
+  $path: String!
+  $templateType: String!
+  $view: String
+  $contextConfiguration: String!
+  $language: String!
+  $workspace: Workspace!
+) {
+  jcr(workspace: $workspace) {
+    nodeByPath(path: $path) {
+      renderedContent(
+        templateType: $templateType
+        view: $view
+        contextConfiguration: $contextConfiguration
+        language: $language
+      ) {
+        output
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
useGQLQuery failed with Unexpected end of JSON input whenever a view was rendered inside a GraphQL POST request (e.g. jContent's previewQueryByWorkspace preview).                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                            
  This happened because GQLHelper reuses the incoming request to issue the nested query, overriding only getParameter. The GraphQL servlet dispatches on HTTP method: the GET parser reads the query from parameters, but the POST parser reads it from the request body — which is already consumed. So the nested query wasn't found (No 
  valid query found in request), the servlet returned an empty body, and JSON.parse("") threw. This only hit the POST render path; normal GET page renders worked, which is why it went unnoticed.                                                                                                                          
                                                                                                                                                                                                                                                                                                                            
  The sub-request now reports GET and a null content type, so the servlet reads the query from the parameters we populate — consistent with the existing renderContext == null path.                                                                                                                         
                                                                                                                                                                                                                                                                                                                            
  I added a Cypress case that renders a useGQLQuery view via a GraphQL POST (renderedContent), covering the previously-untested POST path.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
