### PR TITLE
test: fix self-referential render loop in absolute-area home-page fixture

### DIFF
--- a/jahia-test-module/src/react/server/views/testAbsoluteAreas/TestAbsoluteAreas.tsx
+++ b/jahia-test-module/src/react/server/views/testAbsoluteAreas/TestAbsoluteAreas.tsx
@@ -42,7 +42,7 @@ jahiaComponent(
 
       <h2>Absolute Area with home page</h2>
       <div data-testid="absoluteAreaHomePage">
-        <AbsoluteArea name="pagecontent" parent={renderContext.getSite().getHome()} />
+        <AbsoluteArea name="homePageArea" parent={renderContext.getSite().getHome()} />
       </div>
 
       <h2>Absolute Area with site root node</h2>

--- a/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
+++ b/tests/cypress/e2e/ui/absoluteAreaTest.cy.ts
@@ -9,40 +9,43 @@ describe("Absolute Area test", () => {
   before("Create test page and contents", () => {
     enableModule("event", GENERIC_SITE_KEY);
 
-    // First let's create the content on the home page that will be referenced by areas in the test pages.
+    // Content on the home page referenced by the "absolute area with home page" test. It lives in a
+    // dedicated list (not the home's own "pagecontent"): the absoluteAreaHomePage area renders this
+    // list, and "pagecontent" hosts a testAbsoluteAreas component (testOnHomePage, see below) — pointing
+    // the area at "pagecontent" would make that component render its own container, an infinite loop.
     addNode({
       parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home`,
-      name: "pagecontent",
+      name: "homePageArea",
       primaryNodeType: "jnt:contentList",
     });
 
     addNode({
-      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/pagecontent`,
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/homePageArea`,
       name: "twoColumns",
       primaryNodeType: "javascriptExample:testAreaColumns",
     });
 
     addNode({
-      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/pagecontent/twoColumns`,
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/homePageArea/twoColumns`,
       name: "twoColumns-col-1",
       primaryNodeType: "jnt:contentList",
     });
 
     addNode({
-      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/pagecontent/twoColumns/twoColumns-col-1`,
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/homePageArea/twoColumns/twoColumns-col-1`,
       name: "bigText",
       primaryNodeType: "jnt:bigText",
       properties: [{ name: "text", value: "Column 1", language: "en" }],
     });
 
     addNode({
-      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/pagecontent/twoColumns`,
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/homePageArea/twoColumns`,
       name: "twoColumns-col-2",
       primaryNodeType: "jnt:contentList",
     });
 
     addNode({
-      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/pagecontent/twoColumns/twoColumns-col-2`,
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/homePageArea/twoColumns/twoColumns-col-2`,
       name: "bigText",
       primaryNodeType: "jnt:bigText",
       properties: [{ name: "text", value: "Column 2", language: "en" }],
@@ -82,7 +85,13 @@ describe("Absolute Area test", () => {
       primaryNodeType: "jnt:bigText",
       properties: [{ name: "text", value: "Home limited edit area content", language: "en" }],
     });
-    // Renders TestAbsoluteAreas directly on the home page, so its main resource is the home page.
+    // Renders TestAbsoluteAreas directly on the home page (in the home's own "pagecontent", the area
+    // rendered by the home template), so its main resource is the home page.
+    addNode({
+      parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home`,
+      name: "pagecontent",
+      primaryNodeType: "jnt:contentList",
+    });
     addNode({
       parentPathOrId: `/sites/${GENERIC_SITE_KEY}/home/pagecontent`,
       name: "testOnHomePage",


### PR DESCRIPTION
## Summary

Removes an infinite render loop in the `absoluteAreaTest` e2e fixture — the most likely cause of the nightly `javascript-modules-engine` failure tracked in #684 (`Limited absolute area editing (home parent)` tests).

## Why

The `readOnly="children"` work added a `testOnHomePage` node — a `testAbsoluteAreas` component — inside the home page's own `pagecontent` list (so its main resource is the home page). But `TestAbsoluteAreas` also renders an `absoluteAreaHomePage` area that pointed at that same `home/pagecontent`. Rendering the area therefore recursed into `testOnHomePage`, which rendered `home/pagecontent` again — a self-referential render loop. Jahia logs `Loop detected while rendering .../home/pagecontent`.

This loop makes the page render heavier/degraded; under CI timing the page-builder fails to capture the area (`Failed to capture areas for page — TypeError: Failed to fetch`), so the `limitedAbsoluteAreaEditHomeParent` element never appears and the two home-parent tests time out. The server-side rendering of the area is otherwise correct (editable on the home page, read-only elsewhere).

## Changes

- `TestAbsoluteAreas.tsx`: the `absoluteAreaHomePage` area now targets a dedicated `homePageArea` list instead of the page's own `pagecontent`.
- `absoluteAreaTest.cy.ts`: create the `twoColumns` sample under `home/homePageArea`, and keep `testOnHomePage` in `home/pagecontent` (the list the home template renders). The area and the component no longer share a container, so there is no recursion.

Test infrastructure only (`jahia-test-module` + Cypress); no product code changes, hence no changelog fragment.

## Validation

Built the engine + test module from this branch, deployed on a current `jahia-ee-dev:8-SNAPSHOT`, and ran the spec in both root and custom-context:

- `absoluteAreaTest.cy.ts` → 13/13 passing.
- Server render no longer logs `Loop detected`.

Note: the nightly failure could not be reproduced locally (it is CI-timing/environment sensitive), so this removes the render loop that is the most likely trigger — to be confirmed by the next nightly.

## Documentation

None.
