### PR TITLE
feat(create-module): add non-interactive flags for scripted scaffolding

### DIFF
--- a/.chachalog/Nq7xKd2V.md
+++ b/.chachalog/Nq7xKd2V.md
@@ -1,0 +1,12 @@
+---
+# Allowed version bumps: patch, minor, major
+javascript-modules: minor
+---
+
+`npm init @jahia/module` can now scaffold a project without a single prompt, which makes it usable from scripts, CI pipelines and coding agents (#701):
+
+```bash
+npm init @jahia/module@latest my-module -- --template hello-world --yes
+```
+
+Available flags: `--template <hello-world|template-set|module>`, `--path <dir>`, `--yes`, `--interactive` and `--help`. The wizard is unchanged when no flag is passed, and only asks for what the flags did not provide. Without a terminal, a missing input prints the usage and exits with code 1 instead of waiting forever.

--- a/docs/1-getting-started/1-dev-environment/README.md
+++ b/docs/1-getting-started/1-dev-environment/README.md
@@ -44,6 +44,18 @@ We'll create a new project using Jahia's [@jahia/create-module](https://www.npmj
 npm init @jahia/module@latest hydrogen
 ```
 
+The CLI asks you for the module name, its location and the type of module you want. Every answer can
+also be passed as a flag, which is handy for scripts, CI pipelines or coding agents: the command
+below creates the exact same project without asking anything.
+
+```bash
+# Same thing, without a single prompt
+npm init @jahia/module@latest hydrogen -- --template hello-world --yes
+```
+
+Available templates are `hello-world` (the default), `template-set` and `module`. Run
+`npm init @jahia/module@latest -- --help` to list all the flags.
+
 Once your project is ready, the tool will suggest you to run a few commands to start it. **Make sure Docker Desktop is running** and run them all in order to start your new project.
 
 Please note that git commands, while optional, are strongly recommended. If `code .` doesn't work, open your code editor and open the project folder manually.

--- a/javascript-create-module/README.md
+++ b/javascript-create-module/README.md
@@ -12,4 +12,25 @@ npm init @jahia/module@latest <module-name>
 
 It creates a new JavaScript Module in a directory named `module-name` in the current working directory.
 
+## Non-interactive usage
+
+The CLI asks for anything it was not given. Pass every input as a flag to scaffold a module without
+a single prompt, from a script, a CI pipeline or a coding agent:
+
+```
+npm init @jahia/module@latest my-module -- --template hello-world --yes
+```
+
+| Flag                      | Description                                                        |
+| ------------------------- | ------------------------------------------------------------------ |
+| `<name>`                  | Module name, lowercase letters, digits and hyphens only            |
+| `-t, --template <preset>` | Module preset: `hello-world` (default), `template-set` or `module` |
+| `-p, --path <dir>`        | Directory to create the module in, defaults to `./<name>`          |
+| `-y, --yes`               | Use the defaults for everything not passed as a flag               |
+| `-i, --interactive`       | Force the interactive wizard, even without a terminal              |
+| `-h, --help`              | Print the usage                                                    |
+
+Without a terminal, the CLI never waits for an answer: if an input is missing, it prints the usage
+on stderr and exits with code 1.
+
 See the [Getting Started guide](https://academy.jahia.com/tutorials-get-started/front-end-developer/setting-up-your-dev-environment#create-a-new-project) for more information.

--- a/javascript-create-module/index.js
+++ b/javascript-create-module/index.js
@@ -4,12 +4,148 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { styleText } from "node:util";
+import { parseArgs, styleText } from "node:util";
 import pkg from "./package.json" with { type: "json" };
+
+/**
+ * The module presets: single source of truth, shared by the interactive wizard and the `--template`
+ * flag. Each preset is a list of templates copied on top of each other, in order.
+ */
+const TEMPLATES = {
+  "hello-world": {
+    // This module is created by combining 3 templates:
+    templates: ["module", "template-set", "hello-world"],
+    label: "A minimal Hello World template set",
+    hint: "Recommended for discovery",
+  },
+  "template-set": {
+    templates: ["module", "template-set"],
+    label: "An empty template set",
+    hint: "You want to start from scratch",
+  },
+  "module": {
+    templates: ["module"],
+    label: "An empty module",
+    hint: "Slightly more than an empty directory",
+  },
+};
+
+/** Preset used when `--yes` is passed without `--template`. */
+const DEFAULT_TEMPLATE = "hello-world";
+
+/** Validates a module name, returns an error message when it is invalid. */
+const validateName = (/** @type {string} */ value) => {
+  if (!/^[a-z]/.test(value)) return "Module name must start with a lowercase letter.";
+  if (!/^[a-z0-9-]+$/.test(value))
+    return "Module name can only contain lowercase letters, numbers, and hyphens.";
+};
+
+/** Validates an output path, returns an error message when it is invalid. */
+const validatePath = (/** @type {string} */ value) => {
+  if (value.trim() === "") return "Path cannot be empty.";
+  if (fs.existsSync(value)) return "Path already exists. Please choose a different path.";
+};
 
 /** Renames the `dot` directory to dotfiles and dotdirs. */
 const renameDot = (/** @type {string} */ name) =>
   name.startsWith(`dot${path.sep}`) ? `.${name.slice(4)}` : name;
+
+const usage = `Jahia JavaScript Module Creator
+
+Usage:
+  npm init @jahia/module@latest [name] -- [options]
+
+Arguments:
+  name                     Module name, lowercase letters, digits and hyphens only
+
+Options:
+  -t, --template <preset>  Module preset: ${Object.keys(TEMPLATES).join(" | ")} (default: ${DEFAULT_TEMPLATE})
+  -p, --path <dir>         Directory to create the module in (default: ./<name>)
+  -y, --yes                Use the defaults for everything not passed as a flag
+  -i, --interactive        Force the interactive wizard, even without a terminal
+  -h, --help               Print this help message
+
+Examples:
+  # Interactive wizard
+  npm init @jahia/module@latest
+
+  # Fully unattended, creates ./my-module
+  npm init @jahia/module@latest my-module -- --template hello-world --yes
+`;
+
+/** Prints an error message followed by the usage on stderr, then exits with code 1. */
+const fail = (/** @type {string} */ message) => {
+  console.error(`Error: ${message}\n`);
+  console.error(usage);
+  process.exit(1);
+};
+
+/** @type {ReturnType<typeof parseArgs>} */
+let args;
+
+try {
+  args = parseArgs({
+    args: process.argv.slice(2),
+    allowPositionals: true,
+    options: {
+      template: { type: "string", short: "t" },
+      path: { type: "string", short: "p" },
+      yes: { type: "boolean", short: "y" },
+      interactive: { type: "boolean", short: "i" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}
+
+if (args.values.help) {
+  console.log(usage);
+  process.exit(0);
+}
+
+if (args.positionals.length > 1) {
+  fail(`Unexpected argument: ${args.positionals[1]}`);
+}
+
+/**
+ * Whether prompts can be displayed: a terminal is required, unless the wizard was explicitly
+ * requested. Without it, a missing input is a hard error instead of a prompt: this CLI must never
+ * hang in a script or a CI pipeline.
+ */
+const canPrompt = Boolean(process.stdout.isTTY) || args.values.interactive === true;
+
+/** Whether any flag resolving one of the inputs was passed. */
+const hasFlags =
+  args.values.template !== undefined || args.values.path !== undefined || args.values.yes === true;
+
+/**
+ * Whether to run the full wizard, asking every question. This is the historical behavior, kept
+ * as-is when no flag is passed: the positional argument then only prefills the first prompt.
+ */
+const wizard = args.values.interactive === true || (!hasFlags && canPrompt);
+
+// Resolve and validate everything coming from the command line before printing anything
+let module = /** @type {string | undefined} */ (args.positionals[0]);
+let output = args.values.path;
+let template = args.values.template;
+
+if (module !== undefined) {
+  const error = validateName(module);
+  if (error) fail(error);
+}
+
+if (template !== undefined && !Object.hasOwn(TEMPLATES, template)) {
+  fail(`Unknown template "${template}", expected one of: ${Object.keys(TEMPLATES).join(", ")}.`);
+}
+
+if (output !== undefined) {
+  const error = validatePath(output);
+  if (error) fail(error);
+}
+
+// `--yes` fills in the default for everything that was not passed
+if (args.values.yes) template ??= DEFAULT_TEMPLATE;
 
 try {
   prompts.intro("Jahia JavaScript Module Creator");
@@ -25,61 +161,69 @@ Upgrade guide: ${styleText("underline", "https://nodejs.org/en/download")}
     );
   }
 
-  const module = await prompts.text({
-    message: "What is the name of your module?",
-    placeholder: "a-z, 0-9 and - only",
-    initialValue: process.argv[2],
-    validate(value) {
-      if (!/^[a-z]/.test(value)) return "Module name must start with a lowercase letter.";
-      if (!/^[a-z0-9-]+$/.test(value))
-        return "Module name can only contain lowercase letters, numbers, and hyphens.";
-    },
-  });
+  if (wizard || module === undefined) {
+    if (!canPrompt) fail("Missing module name, pass it as an argument.");
 
-  if (prompts.isCancel(module)) {
-    prompts.cancel("See you soon!");
-    process.exit(0);
+    const answer = await prompts.text({
+      message: "What is the name of your module?",
+      placeholder: "a-z, 0-9 and - only",
+      initialValue: module,
+      validate: validateName,
+    });
+
+    if (prompts.isCancel(answer)) {
+      prompts.cancel("See you soon!");
+      process.exit(0);
+    }
+
+    module = answer;
   }
 
-  const output = await prompts.text({
-    message: "Where do you want to create the module?",
-    initialValue: path.join(process.cwd(), module),
-    validate(value) {
-      if (value.trim() === "") return "Path cannot be empty.";
-      if (fs.existsSync(value)) return "Path already exists. Please choose a different path.";
-    },
-  });
+  if (wizard || output === undefined) {
+    const defaultOutput = path.join(process.cwd(), module);
 
-  if (prompts.isCancel(output)) {
-    prompts.cancel("Goodbye!");
-    process.exit(0);
+    if (!wizard && args.values.yes) {
+      // `--yes` accepts the default path
+      const error = validatePath(defaultOutput);
+      if (error) fail(error);
+      output = defaultOutput;
+    } else {
+      if (!canPrompt) fail("Missing output path, pass --path <dir> or --yes.");
+
+      const answer = await prompts.text({
+        message: "Where do you want to create the module?",
+        initialValue: output ?? defaultOutput,
+        validate: validatePath,
+      });
+
+      if (prompts.isCancel(answer)) {
+        prompts.cancel("Goodbye!");
+        process.exit(0);
+      }
+
+      output = answer;
+    }
   }
 
-  const templates = await prompts.select({
-    message: "Which module type do you want?",
-    options: [
-      {
-        // This module is created by combining 3 templates:
-        value: ["module", "template-set", "hello-world"],
-        label: "A minimal Hello World template set",
-        hint: "Recommended for discovery",
-      },
-      {
-        value: ["module", "template-set"],
-        label: "An empty template set",
-        hint: "You want to start from scratch",
-      },
-      {
-        value: ["module"],
-        label: "An empty module",
-        hint: "Slightly more than an empty directory",
-      },
-    ],
-  });
+  if (wizard || template === undefined) {
+    if (!canPrompt) fail("Missing template, pass --template <preset> or --yes.");
 
-  if (prompts.isCancel(templates)) {
-    prompts.cancel("Have a nice day!");
-    process.exit(0);
+    const answer = await prompts.select({
+      message: "Which module type do you want?",
+      initialValue: template,
+      options: Object.entries(TEMPLATES).map(([value, { label, hint }]) => ({
+        value,
+        label,
+        hint,
+      })),
+    });
+
+    if (prompts.isCancel(answer)) {
+      prompts.cancel("Have a nice day!");
+      process.exit(0);
+    }
+
+    template = answer;
   }
 
   /** Replaces `$MODULE` with the actual module name. */
@@ -90,9 +234,9 @@ Upgrade guide: ${styleText("underline", "https://nodejs.org/en/download")}
       .replaceAll("$NAMESPACE", module.replaceAll("-", ""))
       .replaceAll("$VERSION", pkg.version);
 
-  for (const template of templates) {
+  for (const name of TEMPLATES[template].templates) {
     // Copy the template to the output directory
-    const input = fileURLToPath(new URL(`templates/${template}/`, import.meta.url));
+    const input = fileURLToPath(new URL(`templates/${name}/`, import.meta.url));
     for (const entry of fs.readdirSync(input, { recursive: true, withFileTypes: true })) {
       if (entry.isDirectory()) continue;
 

--- a/javascript-create-module/tests/create-templatesSet-project.test.js
+++ b/javascript-create-module/tests/create-templatesSet-project.test.js
@@ -37,8 +37,9 @@ test("Project creation", async () => {
   // Create a new test-project from within the temp directory
   process.chdir(tempDir);
 
-  // Because the CLI is interactive, we use spawn it and interact with it
-  const child = spawn("node", [indexFile, "project-name"], {
+  // Because the CLI is interactive, we use spawn it and interact with it.
+  // `--interactive` forces the wizard: without a TTY the CLI would otherwise refuse to prompt.
+  const child = spawn("node", [indexFile, "project-name", "--interactive"], {
     stdio: ["pipe", "inherit", "inherit"],
   });
 

--- a/javascript-create-module/tests/non-interactive.test.js
+++ b/javascript-create-module/tests/non-interactive.test.js
@@ -53,7 +53,14 @@ const run = async (args, { cwd = tempFolder, timeout = 5_000 } = {}) => {
     `The CLI did not terminate within ${timeout}ms: it hung on a prompt.`,
   );
 
-  return { code, stdout, stderr };
+  // Node writes its own warnings to stderr (importing package.json is still experimental), and
+  // whether it does depends on the runtime version: they are not output of the CLI under test.
+  const cleanedStderr = stderr
+    .split("\n")
+    .filter((line) => !/^\(node:\d+\)|^\(Use `node --trace-warnings/.test(line))
+    .join("\n");
+
+  return { code, stdout, stderr: cleanedStderr };
 };
 
 /** Creates an empty directory to scaffold into, and returns a path inside of it. */
@@ -182,5 +189,5 @@ test("Prints the usage with --help", async () => {
   for (const template of ["hello-world", "template-set", "module"]) {
     assert.ok(stdout.includes(template), template);
   }
-  assert.equal(stderr, "");
+  assert.equal(stderr.trim(), "");
 });

--- a/javascript-create-module/tests/non-interactive.test.js
+++ b/javascript-create-module/tests/non-interactive.test.js
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, before, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const indexFile = path.join(path.dirname(__dirname), "index.js");
+
+/** @type {string} */
+let tempFolder;
+
+before(() => {
+  // Create a temporary directory
+  tempFolder = fs.mkdtempSync(path.join(os.tmpdir(), "create-module-"));
+});
+
+after(() => {
+  // Remove the temporary directory
+  fs.rmSync(tempFolder, { recursive: true, force: true });
+});
+
+/**
+ * Runs the CLI without any terminal attached: every stream is a pipe, and nothing is ever written
+ * to stdin. A prompt would therefore hang forever, which the timeout turns into a test failure.
+ *
+ * @param {string[]} args CLI arguments
+ * @param {{ cwd?: string; timeout?: number }} [options]
+ * @returns {Promise<{ code: number | null; stdout: string; stderr: string }>}
+ */
+const run = async (args, { cwd = tempFolder, timeout = 5_000 } = {}) => {
+  const child = spawn(process.execPath, [indexFile, ...args], {
+    cwd,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf-8").on("data", (chunk) => (stdout += chunk));
+  child.stderr.setEncoding("utf-8").on("data", (chunk) => (stderr += chunk));
+
+  const timer = setTimeout(() => child.kill("SIGKILL"), timeout);
+  const [code] = await once(child, "exit");
+  clearTimeout(timer);
+
+  assert.notEqual(
+    code,
+    null,
+    `The CLI did not terminate within ${timeout}ms: it hung on a prompt.`,
+  );
+
+  return { code, stdout, stderr };
+};
+
+/** Creates an empty directory to scaffold into, and returns a path inside of it. */
+const target = (/** @type {string} */ name) =>
+  path.join(fs.mkdtempSync(path.join(tempFolder, "test-")), name);
+
+test("Scaffolds a hello-world module without any prompt", async () => {
+  const output = target("foo");
+  const { code, stdout } = await run(["foo", "--template", "hello-world", "--path", output]);
+
+  assert.equal(code, 0);
+  assert.match(stdout, /Successfully created a new Jahia module project!/);
+
+  // The module name is templated in package.json
+  const pkg = JSON.parse(fs.readFileSync(path.join(output, "package.json"), "utf-8"));
+  assert.equal(pkg.name, "foo");
+  assert.equal(pkg.jahia.name, "foo");
+
+  // The CND namespace is templated
+  const cnd = fs.readFileSync(path.join(output, "settings", "definitions.cnd"), "utf-8");
+  assert.match(cnd, /<foo = 'https:\/\/example\.com\/foo\/nt\/1\.0'>/);
+  assert.doesNotMatch(cnd, /\$NAMESPACE|\$MODULE/);
+
+  // Dotfiles and dotdirs have been renamed
+  for (const file of [".env", ".gitignore", ".node-version", ".vscode/settings.json"]) {
+    assert.ok(fs.existsSync(path.join(output, file)), file);
+  }
+  assert.ok(!fs.existsSync(path.join(output, "dot")));
+
+  // Hello World components are there
+  assert.ok(fs.existsSync(path.join(output, "src/components/Hello/World/default.server.tsx")));
+});
+
+test("Defaults the path to <cwd>/<name> with --yes", async () => {
+  const cwd = fs.mkdtempSync(path.join(tempFolder, "test-"));
+  const { code } = await run(["my-module", "--yes"], { cwd });
+
+  assert.equal(code, 0);
+
+  const output = path.join(cwd, "my-module");
+  const pkg = JSON.parse(fs.readFileSync(path.join(output, "package.json"), "utf-8"));
+  assert.equal(pkg.name, "my-module");
+
+  // A hyphenated name gets a hyphen-free CND namespace
+  const cnd = fs.readFileSync(path.join(output, "settings", "definitions.cnd"), "utf-8");
+  assert.match(cnd, /<mymodule = 'https:\/\/example\.com\/my-module\/nt\/1\.0'>/);
+
+  // --yes defaults to the hello-world preset
+  assert.ok(fs.existsSync(path.join(output, "src/components/Hello/World/default.server.tsx")));
+});
+
+test("Scaffolds the template-set preset", async () => {
+  const output = target("bar");
+  const { code } = await run(["bar", "--template", "template-set", "--path", output]);
+
+  assert.equal(code, 0);
+  // Template set files are there…
+  assert.ok(fs.existsSync(path.join(output, "src/templates/Page/basic.server.tsx")));
+  assert.ok(fs.existsSync(path.join(output, "settings/template-thumbnail.png")));
+  // …but not the Hello World ones
+  assert.ok(!fs.existsSync(path.join(output, "src/components")));
+});
+
+test("Scaffolds the module preset", async () => {
+  const output = target("baz");
+  const { code } = await run(["baz", "--template", "module", "--path", output]);
+
+  assert.equal(code, 0);
+  // The bare module files are there…
+  assert.ok(fs.existsSync(path.join(output, "settings/definitions.cnd")));
+  assert.ok(fs.existsSync(path.join(output, "vite.config.mjs")));
+  // …but neither the template set nor the Hello World ones
+  assert.ok(!fs.existsSync(path.join(output, "src/templates")));
+  assert.ok(!fs.existsSync(path.join(output, "src/components")));
+});
+
+test("Rejects an invalid module name", async () => {
+  const output = target("invalid");
+  const { code, stderr } = await run(["Foo!", "--path", output, "--yes"]);
+
+  assert.equal(code, 1);
+  // Same message as the wizard validator
+  assert.match(stderr, /Module name must start with a lowercase letter\./);
+  assert.ok(!fs.existsSync(output));
+});
+
+test("Rejects an existing output path", async () => {
+  const output = target("existing");
+  fs.mkdirSync(output);
+  const { code, stderr } = await run(["foo", "--path", output, "--yes"]);
+
+  assert.equal(code, 1);
+  // Same message as the wizard validator
+  assert.match(stderr, /Path already exists\. Please choose a different path\./);
+  assert.deepEqual(fs.readdirSync(output), []);
+});
+
+test("Rejects an unknown template", async () => {
+  const output = target("unknown");
+  const { code, stderr } = await run(["foo", "--template", "nope", "--path", output]);
+
+  assert.equal(code, 1);
+  assert.match(stderr, /Unknown template "nope"/);
+});
+
+test("Fails fast without a terminal when an input is missing", async () => {
+  // No flag at all: the wizard cannot run, the CLI must exit instead of waiting on stdin
+  const { code, stderr } = await run([]);
+
+  assert.equal(code, 1);
+  assert.match(stderr, /Missing module name/);
+  assert.match(stderr, /Usage:/);
+
+  // A name is not enough either, the path and the template are still missing
+  const partial = await run(["foo"]);
+  assert.equal(partial.code, 1);
+  assert.match(partial.stderr, /Usage:/);
+});
+
+test("Prints the usage with --help", async () => {
+  const { code, stdout, stderr } = await run(["--help"]);
+
+  assert.equal(code, 0);
+  assert.match(stdout, /Usage:/);
+  assert.match(stdout, /--template <preset>/);
+  for (const template of ["hello-world", "template-set", "module"]) {
+    assert.ok(stdout.includes(template), template);
+  }
+  assert.equal(stderr, "");
+});


### PR DESCRIPTION
Closes #701 — part of EPIC #698 (developer experience).

## Problem

`npm init @jahia/module` only ever asks its three questions interactively. There is no way to scaffold a module from a CI job, a documentation script, or a coding agent — piping stdin confuses the prompt renderer, so the only workaround is driving it with `expect`.

## Change

Arguments are parsed with `node:util`'s `parseArgs` (no new dependency):

```sh
npm init @jahia/module@latest my-module -- --template hello-world --yes
```

| Flag | Effect |
|---|---|
| `[name]` | module name, positional |
| `-t, --template <preset>` | `hello-world` \| `template-set` \| `module` |
| `-p, --path <dir>` | output directory (default `./<name>`) |
| `-y, --yes` | take defaults for whatever was not passed |
| `-i, --interactive` | force the wizard even without a terminal |
| `-h, --help` | usage |

Resolution rules:

- everything resolvable → no prompt at all;
- some inputs missing, on a terminal → prompt only for those, prefilled from the flags;
- some inputs missing, no terminal → usage on stderr and exit 1. **The CLI must never hang in a pipeline.**
- no flags at all, on a terminal → the historical wizard, unchanged.

The presets and the two validators are now declared once and shared by the wizard and the flag path, so the two can't drift.

## Verification

`node --test` in `javascript-create-module` → 10 tests, 0 failures: the three presets scaffold correctly, `--yes` defaults the path, invalid name / existing path / unknown template each exit 1 with the wizard's own message, a non-TTY run without flags exits rather than hanging (guarded by a timeout in the test), and `--help` exits 0.

A real scaffold was then inspected: templated `package.json` name, CND namespaces, dotfile renaming, no `$MODULE`/`$NAMESPACE`/`$VERSION` left behind.

## Note for the reviewer

The pre-existing wizard test spawns the CLI with piped stdio, i.e. no TTY — which the new fail-fast rule would turn into an exit 1. It now passes `--interactive`, a one-line change, and still exercises all three prompts. The alternative was dropping the fail-fast rule, which is the point of the issue.

Authored with Claude Code and reviewed before pushing; the test output above was reproduced independently.