### PR TITLE
ci: validate the reduced on-code-change inputs (do not merge)

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -14,20 +14,15 @@ on:
 
 jobs:
   on-code-change:
-    uses: Jahia/jahia-modules-action/.github/workflows/reusable-on-code-change.yml@v2
+    # TEMPORARY: pinned to the branch of Jahia/jahia-modules-action#405 to validate that the
+    # inputs dropped below are correctly derived. This PR is throw-away and must not be merged.
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-on-code-change.yml@ci/reduce-on-code-change-inputs
     secrets: inherit
     with:
-      static_analysis_auditci_level: critical
-      build_container_image: ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-mvn-loaded
-      module_branch: ${{ github.ref }}
-      sonar_analysis_primary_release_branch: main
-      integration_tests_standalone_execute: true
       module_id: javascript-modules-engine
-      integration_tests_testrail_project: Javascript Modules Engine
-      integration_tests_jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
+      build_container_image: ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-mvn-loaded
       integration_tests_provisioning_manifest: provisioning-manifest-build.yml
-      integration_tests_should_use_build_artifacts: true
-      integration_tests_should_skip_testrail: true
+      integration_tests_testrail_project: Javascript Modules Engine
 
   # This workflow ensures that Windows builds are exactly the same as on other platforms
   test-on-windows:


### PR DESCRIPTION
## Do not merge — throw-away

This pull request exists only to run [Jahia/jahia-modules-action#405](https://github.com/Jahia/jahia-modules-action/pull/405) against a real repository. It pins `reusable-on-code-change.yml` to that branch and drops the seven inputs the branch is supposed to derive. It will be deleted once the run has been read.

## Result

[Run 32479908553](https://github.com/Jahia/javascript-modules/actions/runs/32479908553) is green, integration tests included, and every dropped input resolved as intended. The evidence table lives in [jahia-modules-action#405](https://github.com/Jahia/jahia-modules-action/pull/405). This pull request can be deleted.

## What it proves

The caller keeps four inputs instead of eleven:

```yaml
with:
  module_id: javascript-modules-engine
  build_container_image: ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-mvn-loaded
  integration_tests_provisioning_manifest: provisioning-manifest-build.yml
  integration_tests_testrail_project: Javascript Modules Engine
```

| Dropped input | What the run must show |
|---|---|
| `module_branch` | every job checks out this pull request's ref |
| `sonar_analysis_primary_release_branch` | the Sonar analysis compares against `main`, resolved from the base of this pull request |
| `integration_tests_standalone_execute` | the standalone integration tests run, inferred from the provisioning manifest |
| `integration_tests_jahia_image` | the tests start `ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT` |
| `integration_tests_should_skip_testrail` | TestRail stays skipped |
| `integration_tests_should_use_build_artifacts` | the build artifacts are still downloaded |
| `static_analysis_auditci_level` | audit-ci still runs at `critical` |

`build_container_image` stays because this repository builds on JDK 17, not the shared default of 11.
