### PR TITLE
ci: drop the on-code-change inputs the shared workflow now derives

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -17,17 +17,10 @@ jobs:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-on-code-change.yml@v2
     secrets: inherit
     with:
-      static_analysis_auditci_level: critical
-      build_container_image: ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-mvn-loaded
-      module_branch: ${{ github.ref }}
-      sonar_analysis_primary_release_branch: main
-      integration_tests_standalone_execute: true
       module_id: javascript-modules-engine
-      integration_tests_testrail_project: Javascript Modules Engine
-      integration_tests_jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
+      build_container_image: ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-mvn-loaded
       integration_tests_provisioning_manifest: provisioning-manifest-build.yml
-      integration_tests_should_use_build_artifacts: true
-      integration_tests_should_skip_testrail: true
+      integration_tests_testrail_project: Javascript Modules Engine
 
   # This workflow ensures that Windows builds are exactly the same as on other platforms
   test-on-windows:


### PR DESCRIPTION
## What

Drop the seven inputs [jahia-modules-action#405](https://github.com/Jahia/jahia-modules-action/pull/405) made unnecessary, released in [v2.65.0](https://github.com/Jahia/jahia-modules-action/releases/tag/v2.65.0). Eleven inputs become four:

```yaml
with:
  module_id: javascript-modules-engine
  build_container_image: ghcr.io/jahia/jahia-docker-mvn-cache:17-jdk-noble-mvn-loaded
  integration_tests_provisioning_manifest: provisioning-manifest-build.yml
  integration_tests_testrail_project: Javascript Modules Engine
```

`build_container_image` stays because this repository builds on JDK 17, where the shared default is 11.

## Dropped because the workflow derives them

`module_branch`, `sonar_analysis_primary_release_branch`, `integration_tests_standalone_execute`.

## Dropped because the value is now the default

`static_analysis_auditci_level` (`critical`), `integration_tests_jahia_image` (`ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT`), `integration_tests_should_skip_testrail` (`true`).

## Dropped because it never did anything

`integration_tests_should_use_build_artifacts` is deprecated and ignored — build artifacts are downloaded whenever they exist.

## One visible change

Test artifacts are renamed from `standalone-tests-<run>` to `standalone-javascript-modules-engine-<run>`: the prefix now comes from `module_id`. No workflow file in the organisation references the old name.

This exact caller already ran green against the change before it merged, in the throw-away [#726](https://github.com/Jahia/javascript-modules/pull/726) ([run 32485354032](https://github.com/Jahia/javascript-modules/actions/runs/32485354032)), integration tests included. That pull request is now redundant and can be closed.
