### PR TITLE
docs(hydrogen): mark the current page in the sample nav

### DIFF
--- a/samples/hydrogen/src/components/NavBar/default.server.tsx
+++ b/samples/hydrogen/src/components/NavBar/default.server.tsx
@@ -1,4 +1,4 @@
-import { buildNodeUrl, getChildNodes, jahiaComponent } from "@jahia/javascript-modules-library";
+import { getChildNodes, jahiaComponent, JLink } from "@jahia/javascript-modules-library";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
 import classes from "./component.module.css";
 
@@ -11,24 +11,22 @@ jahiaComponent(
     componentType: "view",
     nodeType: "hydrogen:navBar",
     displayName: "NavBar",
+    // JLink emits aria-current on the page being rendered, which is not part of the fragment
+    // cache key unless the view says so. Without this the nav would be cached once and replayed,
+    // marking the same entry current on every page.
+    properties: { "cache.mainResource": "true" },
   },
-  (_, { renderContext, mainNode }) => (
+  (_, { renderContext }) => (
     <nav className={classes.nav}>
       <ul>
         {getChildPages(renderContext.getSite()).map((page) => (
           <li key={page.getPath()}>
-            <a href={buildNodeUrl(page)} aria-current={page === mainNode ? "page" : undefined}>
-              {page.getProperty("jcr:title").getString()}
-            </a>
+            {/* No children: the label comes from the page itself */}
+            <JLink node={page} />
             <ul>
               {getChildPages(page).map((page) => (
                 <li key={page.getPath()}>
-                  <a
-                    href={buildNodeUrl(page)}
-                    aria-current={page === mainNode ? "page" : undefined}
-                  >
-                    {page.getProperty("jcr:title").getString()}
-                  </a>
+                  <JLink node={page} />
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary

Makes the current page actually show as current in the hydrogen navigation. Stacked on #751; the diff here is nine lines in one sample file.

## Why

The nav marked the current entry with `aria-current={page === mainNode ? "page" : undefined}`. Both sides are Graal host proxies wrapping a JCR node, and two proxies for the same node are not the same object — so the test never passed and `aria-current` never appeared. `<JLink>` compares identifiers instead.

## Changes

- Both link sites become `<JLink node={page} />`. No children, so the label comes from the page's displayable name.
- The view declares `properties: { "cache.mainResource": "true" }`. Current-page state is a function of the main resource, and `PathCacheKeyPartGenerator` leaves the main resource out of the fragment cache key unless the view opts in — so without this the nav would be cached once and replayed on every page with the same entry marked current. Nothing in this monorepo declared the property before; core declares it on `jnt_navMenu`, `jnt_area` and the other main-resource-dependent views, and Jahia/luxe-jahia-demo declares it on its own nav.

## Validation

- `tsc --noEmit` on `samples/hydrogen` and `eslint` both clean, against the library built from this branch. `prettier --check` clean.
- **Not run on an instance.** The caching claim is the whole point of the change and it is exactly what a unit test cannot reach: the case to check is the same nav rendered on two pages through an `AbsoluteArea`, asserting `aria-current` follows the page. That is #759's third box and #755's Cypress case.

## Why it is separate from #751

#751 adopts the API mechanically. This changes what the reference sample renders — `aria-current` appears where it never did, on the navigation every new module copies — and it introduces a caching rule the docs have never stated. Worth its own review rather than one line in a 12-file diff.

Part of #759. Depends on #751.
